### PR TITLE
feat: log browser (`repartee l`)

### DIFF
--- a/docs/superpowers/plans/2026-05-09-log-browser.md
+++ b/docs/superpowers/plans/2026-05-09-log-browser.md
@@ -1,0 +1,1381 @@
+# Log Browser Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `repartee l` (alias `logs`) subcommand that opens a read-only TUI log browser over the SQLite history, reusing the entire existing layout — sidebar / topic bar / chat view / status line / input bar — with pseudo-networks synthesised from the database.
+
+**Architecture:** Standalone process (no fork, no IRC, no daemon link) that opens the message DB read-only via SQLite WAL, builds a sidebar of pseudo-`Connection`s + `BufferType::Log` buffers from `SELECT DISTINCT (network, buffer) FROM messages`, and lazy-paginates content via the existing `query::get_messages` API. The whole thing is gated by a single `App::log_browser_mode: bool` flag — every chat-mode entry point in `App::run` either branches on this flag or is short-circuited.
+
+**Tech Stack:** Rust 2024, ratatui 0.30, tokio (current_thread), rusqlite (existing dependency, used in read-only `mode=ro&immutable=1` URI), no new crates.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-09-log-browser-design.md`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/state/buffer.rs` | modify | Add `BufferType::Log` enum variant, sort group `2` (same as Channel). Add 4 optional fields used only in log mode. |
+| `src/web/snapshot.rs` | modify | New `BufferType::Log` arm returning `"log"`. |
+| `src/state/mod.rs` | modify | New `BufferType::Log` arm in `script_snapshot`. |
+| `src/storage/db.rs` | modify | New `open_readonly_at(path)` helper using URI `file:<p>?mode=ro&immutable=1`. |
+| `src/storage/query.rs` | modify | New `list_networks`, `list_buffers_for_network`, `buffer_stats` queries. |
+| `src/storage/mod.rs` | modify | New `load_log_db(config)` returning a `LogDb` struct (db handle + crypto key + fts flag). |
+| `src/app/mod.rs` | modify | New `log_browser_mode: bool` field + `log_db: Option<LogDb>` + `log_buffer_meta: HashMap<String, LogBufferMeta>`; gate `start_socket_listener`/`start_web_server`/scripts/autoconnect on the flag. |
+| `src/app/log_browser.rs` | **create** | All log-browser-only methods: `new_log_browser`, `build_log_catalog`, `load_initial_messages`, `load_older_messages`, `compute_buffer_stats`, slash command handlers. |
+| `src/main.rs` | modify | New `repartee l` / `repartee logs` subcommand branch — direct mode like `repartee a`, no fork. |
+| `src/ui/topic_bar.rs` | modify | Branch for log buffer rendering: `📜 Log: <buf> @ <network> • N lines • date_range`. |
+| `src/ui/status_line.rs` | modify | Branch for log mode: `log mode • <net>/<buf> • showing X/Y from <ts>`. |
+| `src/ui/input.rs` | modify | In log mode reject non-`/` input with a transient hint. |
+
+---
+
+## Task 1: Add `BufferType::Log` variant
+
+**Files:**
+- Modify: `src/state/buffer.rs:8-34, 287-294`
+- Modify: `src/web/snapshot.rs:113-115`
+- Modify: `src/state/mod.rs:113-122`
+
+Adding the enum variant first surfaces every match arm that needs updating — the compiler does the work.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/state/buffer.rs` after the existing `BufferType` test block (around line 290):
+
+```rust
+#[test]
+fn log_buffer_sorts_with_channels() {
+    // Log buffers live under pseudo-networks (different connection_id from
+    // any real channel), so the shared sort group is fine.
+    assert_eq!(BufferType::Log.sort_group(), BufferType::Channel.sort_group());
+}
+```
+
+- [ ] **Step 2: Run the test (it fails — variant missing)**
+
+```bash
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet log_buffer_sorts_with_channels 2>&1 | tail -5
+```
+
+Expected: compile error or `no variant Log`.
+
+- [ ] **Step 3: Add the variant**
+
+In `src/state/buffer.rs` add `Log` to the enum, place it after `Shell`:
+
+```rust
+pub enum BufferType {
+    Mentions,
+    Server,
+    Channel,
+    Query,
+    DccChat,
+    Special,
+    Shell,
+    Log,
+}
+```
+
+In the same file, extend `sort_group`:
+
+```rust
+impl BufferType {
+    pub const fn sort_group(&self) -> u8 {
+        match self {
+            Self::Mentions => 0,
+            Self::Server => 1,
+            Self::Channel | Self::Log => 2,
+            Self::Query => 3,
+            Self::DccChat => 4,
+            Self::Special => 5,
+            Self::Shell => 6,
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Update the two match arms in other modules**
+
+`src/web/snapshot.rs` — add `BufferType::Log => "log",` next to the existing `Shell` arm.
+
+`src/state/mod.rs` — in the `script_snapshot` match, add `buffer::BufferType::Log => "log",` next to the existing `Shell` arm.
+
+- [ ] **Step 5: Build + run tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+Expected: build OK, all tests pass (1067+1).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/state/buffer.rs src/web/snapshot.rs src/state/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(buffer): add BufferType::Log variant"
+```
+
+---
+
+## Task 2: Buffer fields for log metadata
+
+**Files:**
+- Modify: `src/state/buffer.rs` (Buffer struct around line 145)
+
+Four optional fields, all `None` / `false` for non-log buffers. Cheap memory overhead, avoids a separate `HashMap<buffer_id, LogMeta>` lookup on every render.
+
+- [ ] **Step 1: Add fields to `Buffer`**
+
+In `src/state/buffer.rs`, locate the `Buffer` struct and add at the end (after `peer_handle`):
+
+```rust
+    // Populated only when buffer_type == BufferType::Log. Cached at activation
+    // time so the topic-bar render doesn't requery the DB every frame.
+    #[serde(default)]
+    pub log_total_lines: Option<u64>,
+    #[serde(default)]
+    pub log_oldest_ts: Option<i64>,
+    #[serde(default)]
+    pub log_newest_ts: Option<i64>,
+    /// Set true once a paginated `load_older` returns fewer rows than
+    /// requested — i.e. we've reached the start of the recorded log.
+    #[serde(default)]
+    pub history_exhausted: bool,
+```
+
+- [ ] **Step 2: Update every `Buffer { ... }` construction**
+
+The compiler will name them. Run a build to find sites:
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | grep -E "error\[E0063\]" | head -10
+```
+
+For each missing-field error site, add the four defaults — copy-paste:
+
+```rust
+    log_total_lines: None,
+    log_oldest_ts: None,
+    log_newest_ts: None,
+    history_exhausted: false,
+```
+
+Sites to expect (grep before/after to verify):
+
+```bash
+grep -rn "Buffer {$\|Buffer {$" /home/projekt/dev/repartee/src --include="*.rs" | head -20
+```
+
+Repeat the build / paste loop until clean.
+
+- [ ] **Step 3: Build + test**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+Expected: build OK, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(buffer): cache log-mode metadata on Buffer"
+```
+
+---
+
+## Task 3: SQLite read-only open helper
+
+**Files:**
+- Modify: `src/storage/db.rs:215-220`
+
+URI form `file:<path>?mode=ro` lets the daemon keep writing through WAL while we read.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `tests` module at end of `src/storage/db.rs`:
+
+```rust
+#[test]
+fn open_readonly_rejects_writes() {
+    let dir = std::env::temp_dir().join("repartee_logbrowser_ro_test");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("messages.db");
+
+    // Seed via the writable opener.
+    let path_str = path.to_str().unwrap();
+    let rw = open_database_at(path_str, false).unwrap();
+    rw.execute(
+        "INSERT INTO messages (timestamp, network, buffer, message_type, nick, text) \
+         VALUES (?1, 'libera', '#test', 'message', 'ada', 'hello')",
+        rusqlite::params![100],
+    )
+    .unwrap();
+    drop(rw);
+
+    let ro = open_readonly_at(path_str).unwrap();
+    let count: i64 = ro
+        .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+        .unwrap();
+    assert_eq!(count, 1);
+
+    let write_err =
+        ro.execute("INSERT INTO messages (timestamp, network, buffer, message_type, nick, text) \
+                    VALUES (1, 'a','b','message','c','d')", []);
+    assert!(write_err.is_err(), "read-only handle must reject writes");
+
+    std::fs::remove_dir_all(&dir).unwrap();
+}
+```
+
+- [ ] **Step 2: Run test (fails — function missing)**
+
+```bash
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet open_readonly_rejects_writes 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Implement `open_readonly_at`**
+
+Add right below `open_database_at` in `src/storage/db.rs`:
+
+```rust
+/// Open the message database read-only.
+///
+/// Uses `mode=ro` URI parameter so the SQLite WAL writer side can
+/// keep flushing concurrently — the log browser never writes, the
+/// daemon never blocks. No schema creation: the database must
+/// already exist.
+pub fn open_readonly_at(path: &str) -> rusqlite::Result<Connection> {
+    let uri = format!("file:{path}?mode=ro");
+    let db = Connection::open_with_flags(
+        &uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )?;
+    apply_pragmas(&db)?;
+    Ok(db)
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet open_readonly_rejects_writes 2>&1 | tail -3
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/db.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(storage): read-only DB open helper"
+```
+
+---
+
+## Task 4: Catalog queries (`list_networks`, `list_buffers_for_network`, `buffer_stats`)
+
+**Files:**
+- Modify: `src/storage/query.rs`
+
+These are the queries that populate the sidebar and topic-bar metadata.
+
+- [ ] **Step 1: Write the failing tests**
+
+At the end of the existing `tests` module in `src/storage/query.rs`:
+
+```rust
+#[test]
+fn list_networks_returns_distinct_sorted() {
+    let db = open_database(false).unwrap();
+    db.execute_batch(
+        "INSERT INTO messages (timestamp, network, buffer, message_type, nick, text) VALUES \
+         (1, 'libera',  '#rust',   'message', 'ada', 'a'), \
+         (2, 'libera',  '#polska', 'message', 'ada', 'b'), \
+         (3, 'oftc',    '#debian', 'message', 'ada', 'c'), \
+         (4, 'libera',  '#rust',   'message', 'ada', 'd'), \
+         (5, 'ircnet',  '#pl',     'message', 'ada', 'e');",
+    )
+    .unwrap();
+
+    assert_eq!(list_networks(&db).unwrap(), vec!["ircnet", "libera", "oftc"]);
+}
+
+#[test]
+fn list_buffers_for_network_filters_correctly() {
+    let db = open_database(false).unwrap();
+    db.execute_batch(
+        "INSERT INTO messages (timestamp, network, buffer, message_type, nick, text) VALUES \
+         (1, 'libera', '#rust',   'message', 'a', 'x'), \
+         (2, 'libera', '#polska', 'message', 'a', 'x'), \
+         (3, 'oftc',   '#debian', 'message', 'a', 'x'), \
+         (4, 'libera', '#rust',   'message', 'a', 'y');",
+    )
+    .unwrap();
+
+    assert_eq!(
+        list_buffers_for_network(&db, "libera").unwrap(),
+        vec!["#polska", "#rust"]
+    );
+    assert_eq!(
+        list_buffers_for_network(&db, "oftc").unwrap(),
+        vec!["#debian"]
+    );
+    assert!(list_buffers_for_network(&db, "missing").unwrap().is_empty());
+}
+
+#[test]
+fn buffer_stats_returns_count_and_range() {
+    let db = open_database(false).unwrap();
+    db.execute_batch(
+        "INSERT INTO messages (timestamp, network, buffer, message_type, nick, text) VALUES \
+         (100,  'libera', '#rust', 'message', 'a', 'x'), \
+         (200,  'libera', '#rust', 'message', 'a', 'y'), \
+         (50,   'libera', '#rust', 'message', 'a', 'z'), \
+         (9999, 'libera', '#other','message', 'a', 'q');",
+    )
+    .unwrap();
+
+    let stats = buffer_stats(&db, "libera", "#rust").unwrap();
+    assert_eq!(stats, Some((3, 50, 200)));
+    assert_eq!(buffer_stats(&db, "libera", "#unknown").unwrap(), None);
+}
+```
+
+- [ ] **Step 2: Run tests (fail — functions missing)**
+
+```bash
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet list_networks_returns_distinct_sorted list_buffers_for_network_filters_correctly buffer_stats_returns_count_and_range 2>&1 | tail -5
+```
+
+- [ ] **Step 3: Implement the three queries**
+
+Add to `src/storage/query.rs` near the other public functions:
+
+```rust
+/// Distinct networks present in the message log, sorted ascending.
+pub fn list_networks(db: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = db.prepare("SELECT DISTINCT network FROM messages ORDER BY network")?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+    rows.collect()
+}
+
+/// Distinct buffers logged for a given network, sorted ascending.
+pub fn list_buffers_for_network(
+    db: &Connection,
+    network: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = db.prepare(
+        "SELECT DISTINCT buffer FROM messages WHERE network = ?1 ORDER BY buffer",
+    )?;
+    let rows = stmt.query_map(rusqlite::params![network], |r| r.get::<_, String>(0))?;
+    rows.collect()
+}
+
+/// `(line_count, oldest_ts, newest_ts)` for a given network/buffer pair, or
+/// `None` if no messages exist there. Cached on the `Buffer` at activation.
+pub fn buffer_stats(
+    db: &Connection,
+    network: &str,
+    buffer: &str,
+) -> rusqlite::Result<Option<(u64, i64, i64)>> {
+    let row = db.query_row(
+        "SELECT COUNT(*), MIN(timestamp), MAX(timestamp) \
+         FROM messages WHERE network = ?1 AND buffer = ?2",
+        rusqlite::params![network, buffer],
+        |r| {
+            let count: i64 = r.get(0)?;
+            // MIN/MAX are NULL when count == 0
+            let oldest: Option<i64> = r.get(1)?;
+            let newest: Option<i64> = r.get(2)?;
+            #[expect(clippy::cast_sign_loss, reason = "COUNT(*) is non-negative")]
+            Ok((count as u64, oldest, newest))
+        },
+    )?;
+    Ok(match row {
+        (0, _, _) => None,
+        (n, Some(o), Some(x)) => Some((n, o, x)),
+        _ => None,
+    })
+}
+```
+
+- [ ] **Step 4: Run tests, expect pass**
+
+```bash
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet list_networks_returns_distinct_sorted list_buffers_for_network_filters_correctly buffer_stats_returns_count_and_range 2>&1 | tail -3
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/storage/query.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(storage): catalog queries for log browser"
+```
+
+---
+
+## Task 5: `LogDb` loader (read-only DB + crypto key)
+
+**Files:**
+- Modify: `src/storage/mod.rs`
+
+A small struct that bundles the read-only handle, optional crypto key, and FTS availability. Used by `App::new_log_browser`.
+
+- [ ] **Step 1: Implement the loader**
+
+Add to the bottom of `src/storage/mod.rs` (outside `impl Storage`):
+
+```rust
+/// Read-only handle bundle used by the log browser. Same crypto-key
+/// derivation as `Storage::init`, no writer task spawned.
+pub struct LogDb {
+    pub db: Arc<Mutex<rusqlite::Connection>>,
+    pub crypto_key: Option<aes_gcm::Key<aes_gcm::Aes256Gcm>>,
+    pub has_fts: bool,
+}
+
+/// Open the message database read-only and (when `[storage] encrypt =
+/// true`) load the same AES-256-GCM key the daemon uses. Returns a clear
+/// human-readable error so `repartee l` can print it directly.
+pub fn load_log_db(config: &LoggingConfig) -> Result<LogDb, String> {
+    let db_dir = constants::log_dir();
+    let db_path = db_dir.join("messages.db");
+    if !db_path.exists() {
+        return Err(format!(
+            "no message log at {} — start `repartee` and chat first",
+            db_path.display()
+        ));
+    }
+    let path_str = db_path.to_str().ok_or("invalid log dir path")?;
+    let conn = db::open_readonly_at(path_str)
+        .map_err(|e| format!("failed to open log database: {e}"))?;
+
+    let crypto_key = if config.encrypt {
+        let hex_key = crypto::load_or_create_key()?;
+        Some(crypto::import_key(&hex_key)?)
+    } else {
+        None
+    };
+
+    Ok(LogDb {
+        db: Arc::new(Mutex::new(conn)),
+        crypto_key,
+        has_fts: !config.encrypt,
+    })
+}
+```
+
+`Arc`, `Mutex`, `aes_gcm`, `db`, `crypto`, `constants` are already imported in this file — verify with the existing imports at top.
+
+- [ ] **Step 2: Build**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+```
+
+Expected: OK.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/storage/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(storage): LogDb bundle for log browser"
+```
+
+---
+
+## Task 6: `App::log_browser_mode` flag + `LogDb` field
+
+**Files:**
+- Modify: `src/app/mod.rs` (struct definition + `App::new` defaults)
+
+Field-only addition — populated by the new constructor in Task 7.
+
+- [ ] **Step 1: Add fields to `App`**
+
+In `src/app/mod.rs`, in the `App` struct add:
+
+```rust
+    /// `true` when started via `repartee l` — disables IRC, sockets,
+    /// scripts, autoconnect; rewires sidebar to read from `log_db`.
+    pub log_browser_mode: bool,
+    /// Read-only DB handle when `log_browser_mode == true`. `None`
+    /// otherwise.
+    pub log_db: Option<crate::storage::LogDb>,
+```
+
+- [ ] **Step 2: Initialise in `App::new`**
+
+Find the existing `Self { ... }` constructor inside `App::new` and add the two fields with their defaults at the end (just before the closing brace):
+
+```rust
+            log_browser_mode: false,
+            log_db: None,
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+```
+
+Expected: OK.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(app): log_browser_mode flag and LogDb field"
+```
+
+---
+
+## Task 7: `App::new_log_browser` constructor and catalog builder
+
+**Files:**
+- Create: `src/app/log_browser.rs`
+- Modify: `src/app/mod.rs` (declare submodule, public re-export)
+
+Single home for every method that runs only in log mode.
+
+- [ ] **Step 1: Declare the submodule**
+
+In `src/app/mod.rs` at the top, alongside the other `mod` declarations of submodules:
+
+```rust
+mod log_browser;
+```
+
+- [ ] **Step 2: Create `src/app/log_browser.rs` with constructor + catalog**
+
+```rust
+//! Log-browser-only methods on `App`. Only invoked when
+//! `log_browser_mode == true`. Keeps the chat-mode call sites in
+//! `app/mod.rs` free of log-mode branches.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use chrono::Utc;
+use color_eyre::eyre::Result;
+
+use crate::config;
+use crate::state::buffer::{ActivityLevel, Buffer, BufferType, make_buffer_id};
+use crate::state::connection::{Connection, ConnectionStatus};
+use crate::storage::LogDb;
+
+use super::App;
+
+impl App {
+    /// Connection ID prefix used for log-mode pseudo-networks. Distinct
+    /// from any real network identifier (which the user picks in their
+    /// config TOML) so live and log buffers never collide on
+    /// `make_buffer_id`.
+    pub const LOG_CONN_PREFIX: &'static str = "_log_";
+
+    /// Build an `App` instance configured for the read-only log browser.
+    /// No IRC, no scripts, no web server, no sockets.
+    pub fn new_log_browser() -> Result<Self> {
+        let mut app = Self::new()?;
+        app.log_browser_mode = true;
+
+        let log_db = crate::storage::load_log_db(&app.config.logging)
+            .map_err(|e| color_eyre::eyre::eyre!("{e}"))?;
+        app.log_db = Some(log_db);
+
+        // Wipe any state left over from `App::new`'s default initialisation
+        // (default Status buffer etc.) so build_log_catalog sees a clean
+        // sidebar.
+        app.state.connections.clear();
+        app.state.buffers.clear();
+        app.state.active_buffer_id = None;
+
+        app.build_log_catalog()?;
+        Ok(app)
+    }
+
+    /// Populate `state.connections` and `state.buffers` from the
+    /// distinct (network, buffer) pairs in the log database. Each
+    /// network becomes a synthetic `Connection`, each buffer a
+    /// `BufferType::Log` placeholder with empty `messages` (filled
+    /// lazily when first activated).
+    pub fn build_log_catalog(&mut self) -> Result<()> {
+        let log_db = self
+            .log_db
+            .as_ref()
+            .ok_or_else(|| color_eyre::eyre::eyre!("log catalog requires log_db"))?;
+        let db = log_db.db.lock().expect("log db poisoned");
+
+        let networks = crate::storage::query::list_networks(&db)
+            .map_err(|e| color_eyre::eyre::eyre!("list_networks: {e}"))?;
+
+        // Look up friendly labels from the user's chat config when present
+        // ("libera" -> "Libera Chat" if they configured a server with that
+        // id). Falls back to the network id verbatim.
+        let label_for = |net: &str| -> String {
+            self.config
+                .servers
+                .get(net)
+                .map_or_else(|| net.to_string(), |c| c.label.clone())
+        };
+
+        let mut first_buffer_id: Option<String> = None;
+
+        for net in &networks {
+            let conn_id = format!("{}{net}", Self::LOG_CONN_PREFIX);
+            self.state.add_connection(Connection {
+                id: conn_id.clone(),
+                label: label_for(net),
+                status: ConnectionStatus::Connected,
+                nick: String::new(),
+                user_modes: String::new(),
+                isupport: HashMap::new(),
+                isupport_parsed: crate::irc::isupport::Isupport::new(),
+                error: None,
+                lag: None,
+                lag_pending: false,
+                reconnect_attempts: 0,
+                reconnect_delay_secs: 0,
+                next_reconnect: None,
+                should_reconnect: false,
+                joined_channels: Vec::new(),
+                origin_config: config::ServerConfig {
+                    label: String::new(),
+                    address: String::new(),
+                    port: 0,
+                    tls: false,
+                    tls_verify: true,
+                    autoconnect: false,
+                    channels: vec![],
+                    nick: None,
+                    username: None,
+                    realname: None,
+                    password: None,
+                    sasl_user: None,
+                    sasl_pass: None,
+                    bind_ip: None,
+                    encoding: None,
+                    auto_reconnect: Some(false),
+                    reconnect_delay: None,
+                    reconnect_max_retries: None,
+                    autosendcmd: None,
+                    sasl_mechanism: None,
+                    client_cert_path: None,
+                },
+                local_ip: None,
+                enabled_caps: HashSet::new(),
+                who_token_counter: 0,
+                silent_who_channels: HashSet::new(),
+                silent_banlist_channels: HashSet::new(),
+            });
+
+            let buffers = crate::storage::query::list_buffers_for_network(&db, net)
+                .map_err(|e| color_eyre::eyre::eyre!("list_buffers_for_network: {e}"))?;
+            for buf in buffers {
+                let buf_id = make_buffer_id(&conn_id, &buf);
+                if first_buffer_id.is_none() {
+                    first_buffer_id = Some(buf_id.clone());
+                }
+                self.state.add_buffer(Buffer {
+                    id: buf_id,
+                    connection_id: conn_id.clone(),
+                    buffer_type: BufferType::Log,
+                    name: buf.clone(),
+                    messages: VecDeque::new(),
+                    activity: ActivityLevel::None,
+                    unread_count: 0,
+                    last_read: Utc::now(),
+                    topic: None,
+                    topic_set_by: None,
+                    users: HashMap::new(),
+                    modes: None,
+                    mode_params: None,
+                    list_modes: HashMap::new(),
+                    last_speakers: Vec::new(),
+                    peer_handle: None,
+                    log_total_lines: None,
+                    log_oldest_ts: None,
+                    log_newest_ts: None,
+                    history_exhausted: false,
+                });
+            }
+        }
+
+        if let Some(id) = first_buffer_id {
+            self.state.set_active_buffer(&id);
+        }
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -10
+```
+
+Expected: OK. If there are any "unused" warnings on the new constants, tolerate them — Task 8 will use them.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/log_browser.rs src/app/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(app): log browser constructor + catalog builder"
+```
+
+---
+
+## Task 8: Lazy load — initial + paged history
+
+**Files:**
+- Modify: `src/app/log_browser.rs` (add 2 methods)
+
+- [ ] **Step 1: Add `load_initial_messages` and `load_older_messages`**
+
+Append to `src/app/log_browser.rs` inside the existing `impl App` block:
+
+```rust
+    /// Load the most recent `INITIAL_LIMIT` messages for `buffer_id`.
+    /// Cheap no-op if the buffer already has messages (called every time
+    /// a log buffer is activated). Also populates `log_total_lines`,
+    /// `log_oldest_ts`, `log_newest_ts` once.
+    pub fn load_initial_messages(&mut self, buffer_id: &str) {
+        const INITIAL_LIMIT: usize = 200;
+        let already_loaded = self
+            .state
+            .buffers
+            .get(buffer_id)
+            .is_some_and(|b| !b.messages.is_empty());
+        if already_loaded {
+            return;
+        }
+        let Some(log_db) = &self.log_db else { return };
+        let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else { return };
+        let db = log_db.db.lock().expect("log db poisoned");
+
+        // Always cache stats first so the topic bar gets numbers even if
+        // the buffer happens to have zero messages.
+        if let Ok(Some((count, oldest, newest))) =
+            crate::storage::query::buffer_stats(&db, &net, &buf)
+            && let Some(buffer) = self.state.buffers.get_mut(buffer_id)
+        {
+            buffer.log_total_lines = Some(count);
+            buffer.log_oldest_ts = Some(oldest);
+            buffer.log_newest_ts = Some(newest);
+        }
+
+        match crate::storage::query::get_messages(
+            &db,
+            &net,
+            &buf,
+            None,
+            INITIAL_LIMIT,
+            log_db.crypto_key.is_some(),
+            log_db.crypto_key.as_ref(),
+        ) {
+            Ok(rows) => {
+                let exhausted = rows.len() < INITIAL_LIMIT;
+                drop(db);
+                if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
+                    for row in rows {
+                        buffer.messages.push_back(row.into_buffer_message());
+                    }
+                    buffer.history_exhausted = exhausted;
+                }
+            }
+            Err(e) => tracing::warn!(%buffer_id, "log load_initial failed: {e}"),
+        }
+    }
+
+    /// Prepend up to `PAGE_LIMIT` messages older than the oldest currently
+    /// loaded message. Sets `history_exhausted` when fewer rows are
+    /// returned than requested. No-op if already exhausted or no messages
+    /// loaded yet.
+    pub fn load_older_messages(&mut self, buffer_id: &str) {
+        const PAGE_LIMIT: usize = 200;
+        let Some(buffer) = self.state.buffers.get(buffer_id) else { return };
+        if buffer.history_exhausted {
+            return;
+        }
+        let Some(oldest_msg) = buffer.messages.front() else {
+            self.load_initial_messages(buffer_id);
+            return;
+        };
+        let oldest_ts = oldest_msg.timestamp.timestamp();
+        let Some(log_db) = &self.log_db else { return };
+        let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else { return };
+        let db = log_db.db.lock().expect("log db poisoned");
+        match crate::storage::query::get_messages(
+            &db,
+            &net,
+            &buf,
+            Some(oldest_ts),
+            PAGE_LIMIT,
+            log_db.crypto_key.is_some(),
+            log_db.crypto_key.as_ref(),
+        ) {
+            Ok(rows) => {
+                let exhausted = rows.len() < PAGE_LIMIT;
+                drop(db);
+                if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
+                    // get_messages returns chronological ascending — front
+                    // them in the same order so the buffer stays sorted.
+                    for row in rows.into_iter().rev() {
+                        buffer.messages.push_front(row.into_buffer_message());
+                    }
+                    if exhausted {
+                        buffer.history_exhausted = true;
+                    }
+                }
+            }
+            Err(e) => tracing::warn!(%buffer_id, "log load_older failed: {e}"),
+        }
+    }
+
+    /// Split `<conn_id>/<buffer_name>` where `conn_id` starts with
+    /// `LOG_CONN_PREFIX`, returning `(network, buffer)` without the
+    /// prefix. `None` for ids not produced by `build_log_catalog`.
+    fn split_log_buffer_id(&self, buffer_id: &str) -> Option<(String, String)> {
+        let buffer = self.state.buffers.get(buffer_id)?;
+        let net = buffer
+            .connection_id
+            .strip_prefix(Self::LOG_CONN_PREFIX)?
+            .to_string();
+        Some((net, buffer.name.clone()))
+    }
+```
+
+- [ ] **Step 2: Verify `StoredMessage::into_buffer_message` exists**
+
+```bash
+grep -n "fn into_buffer_message" /home/projekt/dev/repartee/src/storage/types.rs /home/projekt/dev/repartee/src/storage/*.rs
+```
+
+If it doesn't exist, look for whatever conversion the existing `load_backlog` path in `app/backlog.rs` uses — adapt the field-by-field copy here. (Most likely there's a `pub fn into_buffer_message(self) -> Message` or an `impl From<StoredMessage> for Message`. If not, write the conversion inline.)
+
+- [ ] **Step 3: Build**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -10
+```
+
+If `into_buffer_message` doesn't exist, the error will name the right symbol — replace `row.into_buffer_message()` with the correct conversion from `app/backlog.rs`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/log_browser.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(app): lazy initial + paged loading for log buffers"
+```
+
+---
+
+## Task 9: `App::run` gates for log mode
+
+**Files:**
+- Modify: `src/app/mod.rs` (`run` method)
+
+- [ ] **Step 1: Skip socket listener / scripts / web / autoconnect**
+
+In `src/app/mod.rs::App::run`, replace each of these blocks:
+
+```rust
+        if let Err(e) = self.start_socket_listener() {
+            ...
+```
+
+becomes guarded by `if !self.log_browser_mode`:
+
+```rust
+        if !self.log_browser_mode {
+            if let Err(e) = self.start_socket_listener() {
+                if self.detached {
+                    return Err(e.wrap_err("failed to start session socket"));
+                }
+                tracing::warn!("session socket unavailable: {e}");
+            }
+        }
+```
+
+Apply the same `if !self.log_browser_mode { ... }` wrapper around:
+
+- The `autoconnect_ids` collection block (we never want IRC autoconnect)
+- `self.autoload_scripts();`
+- `self.start_web_server().await;`
+- The `pending_autoconnect_ids` initialisation
+- The `start_term_reader` call **stays** — log browser still needs keyboard
+
+For `state.buffers.is_empty()` (default Status creation) — change to also gate on log mode so we don't add a stray Status when log mode wiped it on purpose:
+
+```rust
+        if !self.log_browser_mode && self.state.buffers.is_empty() {
+            Self::create_default_status(&mut self.state);
+        }
+```
+
+- [ ] **Step 2: Build + smoke**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(app): gate IRC/web/scripts/autoconnect on log_browser_mode"
+```
+
+---
+
+## Task 10: `repartee l` / `repartee logs` subcommand
+
+**Files:**
+- Modify: `src/main.rs`
+
+Mirrors the existing `repartee a` / `repartee attach` branch.
+
+- [ ] **Step 1: Add the branch**
+
+In `src/main.rs`, after the existing `args.get(1).map(...) == Some("a") || ... == Some("attach")` block, add a parallel block for `"l"` / `"logs"`:
+
+```rust
+    if args.get(1).map(String::as_str) == Some("l")
+        || args.get(1).map(String::as_str) == Some("logs")
+    {
+        color_eyre::install()?;
+        setup_logging();
+        ui::install_panic_hook();
+        // Pre-fork validation skipped: log mode never forks. Config TOML
+        // is still read inside App::new and any error surfaces here on
+        // the user's TTY directly.
+        constants::ensure_config_dir();
+        return tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(async {
+                let mut app = app::App::new_log_browser()?;
+                if let Ok((cols, rows)) = crossterm::terminal::size() {
+                    app.cached_term_cols = cols;
+                    app.cached_term_rows = rows;
+                }
+                app.terminal = Some(ui::setup_terminal()?);
+                let result = app.run().await;
+                if let Some(ref mut terminal) = app.terminal {
+                    let _ = ui::restore_terminal(terminal);
+                }
+                result
+            });
+    }
+```
+
+- [ ] **Step 2: Build**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Smoke (without DB — should fail clean)**
+
+```bash
+HOME=/tmp/repartee_logbrowser_no_db /home/projekt/dev/repartee/target/debug/repartee l 2>&1 | head -5
+```
+
+Expected: clean error message (no message log) plus a non-zero exit.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(cli): repartee l / logs subcommand"
+```
+
+---
+
+## Task 11: Topic bar log-mode rendering
+
+**Files:**
+- Modify: `src/ui/topic_bar.rs`
+
+- [ ] **Step 1: Branch on active buffer type**
+
+Read `src/ui/topic_bar.rs`'s `render` and add a fallback branch for `BufferType::Log` that formats the message described in the spec:
+
+```rust
+if buf.buffer_type == BufferType::Log {
+    let total = buf.log_total_lines.unwrap_or(0);
+    let range = match (buf.log_oldest_ts, buf.log_newest_ts) {
+        (Some(o), Some(n)) => format!(
+            "{} → {}",
+            format_log_date(o),
+            format_log_date(n),
+        ),
+        _ => String::from("(empty)"),
+    };
+    let net = buf.connection_id.trim_start_matches(crate::app::App::LOG_CONN_PREFIX);
+    let text = format!("📜 Log: {} @ {}  •  {} lines  •  {}", buf.name, net, total, range);
+    // render `text` using the same Style the existing topic uses.
+    return;
+}
+```
+
+Add helper:
+
+```rust
+fn format_log_date(ts: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_default()
+}
+```
+
+(Adjust the `return` placement to match the existing function's flow — likely you'll extract the existing topic render into a common path and only branch on the formatting.)
+
+- [ ] **Step 2: Build + run unit tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/topic_bar.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(ui): topic bar shows log metadata in log mode"
+```
+
+---
+
+## Task 12: Status line log-mode rendering
+
+**Files:**
+- Modify: `src/ui/status_line.rs`
+
+- [ ] **Step 1: Branch on `app.log_browser_mode`**
+
+Read `src/ui/status_line.rs::render` and add at the top:
+
+```rust
+if app.log_browser_mode {
+    use chrono::DateTime;
+    let buf = app.state.active_buffer();
+    let (loaded, total, from) = buf
+        .map(|b| {
+            let total = b.log_total_lines.unwrap_or(0);
+            let loaded = b.messages.len();
+            let from = b
+                .messages
+                .front()
+                .map(|m| m.timestamp.format("%Y-%m-%d %H:%M").to_string())
+                .unwrap_or_else(|| "(empty)".to_string());
+            (loaded, total, from)
+        })
+        .unwrap_or((0, 0, String::from("(no buffer)")));
+    let id = buf.map(|b| b.id.as_str()).unwrap_or("");
+    let text = format!(
+        "log mode • {id} • showing {loaded}/{total} from {from}  •  ↑/↓ scroll • / search • Q quit"
+    );
+    // render `text` with the existing status bar style and return early.
+    return;
+}
+```
+
+(Inline-adapt the early-return shape to match the existing function — the goal is: in log mode, the status bar shows that line and only that line.)
+
+- [ ] **Step 2: Build + tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/ui/status_line.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(ui): status line in log mode"
+```
+
+---
+
+## Task 13: Hook active-buffer change to lazy-load
+
+**Files:**
+- Modify: `src/app/mod.rs` or a small helper
+
+When the user navigates to a log buffer, we need to call `load_initial_messages`. Hook this somewhere in the main loop — a per-tick check is fine and keeps the change minimal.
+
+- [ ] **Step 1: Add tick-time hook**
+
+In `src/app/mod.rs` near the existing 1s tick body (the same arm that calls `check_stale_who_batches`), insert:
+
+```rust
+                    if self.log_browser_mode
+                        && let Some(active_id) = self.state.active_buffer_id.clone()
+                    {
+                        self.load_initial_messages(&active_id);
+                    }
+```
+
+(Idempotent — `load_initial_messages` early-returns if the buffer already has messages.)
+
+- [ ] **Step 2: Build + tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(app): hook log buffer activation to lazy load"
+```
+
+---
+
+## Task 14: Slash-only input filter + `/quit` `/help` `/search`
+
+**Files:**
+- Modify: `src/app/mod.rs` (input handling — search for the place that takes the input line and dispatches commands)
+- Create: `src/commands/handlers_logs.rs`
+
+- [ ] **Step 1: Locate the input dispatch**
+
+```bash
+grep -n "fn execute_command\|fn submit_input\|parse_command" /home/projekt/dev/repartee/src/commands/parser.rs /home/projekt/dev/repartee/src/app/*.rs | head
+```
+
+Find where a submitted input line is split into command vs chat. Probably `App::execute_input_line` or `App::execute_command`. Note the function name for Step 3.
+
+- [ ] **Step 2: Create the log-mode handlers**
+
+Create `src/commands/handlers_logs.rs`:
+
+```rust
+//! Slash command handlers active only when `app.log_browser_mode == true`.
+
+use crate::app::App;
+use crate::commands::helpers::add_local_event;
+
+pub(crate) fn cmd_log_quit(app: &mut App, _args: &[String]) {
+    app.should_quit = true;
+}
+
+pub(crate) fn cmd_log_help(app: &mut App, _args: &[String]) {
+    add_local_event(app, "log mode commands:");
+    add_local_event(app, "  /search <text>   FTS5 / LIKE search in active log");
+    add_local_event(app, "  /quit            exit log browser  (also: q outside input)");
+    add_local_event(app, "  /help            this list");
+}
+
+pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
+    if args.is_empty() {
+        add_local_event(app, "Usage: /search <text>");
+        return;
+    }
+    let query = args.join(" ");
+    let Some(active_id) = app.state.active_buffer_id.clone() else {
+        add_local_event(app, "No active log buffer");
+        return;
+    };
+    let Some((net, buf)) = app.log_buffer_id_parts(&active_id) else {
+        add_local_event(app, "Active buffer is not a log");
+        return;
+    };
+    let Some(log_db) = &app.log_db else {
+        add_local_event(app, "Log DB unavailable");
+        return;
+    };
+    let db = log_db.db.lock().expect("log db poisoned");
+    match crate::storage::query::search_messages(&db, &query, Some(&net), Some(&buf), 100) {
+        Ok(hits) => {
+            drop(db);
+            add_local_event(app, &format!("[{} matches for \"{}\"]", hits.len(), query));
+            for hit in hits {
+                let formatted = format!(
+                    "{}  <{}> {}",
+                    hit.timestamp_human(),
+                    hit.nick.as_deref().unwrap_or("*"),
+                    hit.text
+                );
+                add_local_event(app, &formatted);
+            }
+        }
+        Err(e) => add_local_event(app, &format!("Search failed: {e}")),
+    }
+}
+```
+
+(`App::log_buffer_id_parts` is a public wrapper around `split_log_buffer_id` from Task 8 — promote it from `fn` to `pub(crate) fn` and rename if needed.)
+
+`StoredMessage::timestamp_human` may not exist — replace with `chrono::DateTime::<chrono::Utc>::from_timestamp(hit.timestamp, 0).map(|d| d.format("%Y-%m-%d %H:%M").to_string()).unwrap_or_default()` if so.
+
+- [ ] **Step 3: Wire into command parser**
+
+In `src/commands/registry.rs`, add three command entries for `log_quit`, `log_help`, `log_search`. Their existing `cmd_quit` may already work — check whether registering an alias works. If not, add named entries restricted to log mode (you can predicate dispatch on `app.log_browser_mode` inside the handler that catches unknown).
+
+Simpler: in the dispatch function found in Step 1, if `app.log_browser_mode == true`, route `quit` → `cmd_log_quit`, `help` → `cmd_log_help`, `search` → `cmd_log_search`, and reject anything else with:
+
+```rust
+add_local_event(app, "log mode: only /search, /quit, /help — see /help");
+```
+
+For typed-but-not-prefixed input (chat lines): also gate at the input layer — if `log_browser_mode == true` and the submitted line doesn't start with `/`, reject identically.
+
+- [ ] **Step 4: Add module to commands**
+
+In `src/commands/mod.rs` add:
+
+```rust
+pub mod handlers_logs;
+```
+
+- [ ] **Step 5: Build + tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(log-browser): /search /quit /help and slash-only input filter"
+```
+
+---
+
+## Task 15: Q hotkey + scroll-up trigger
+
+**Files:**
+- Modify: `src/app/mod.rs` (key event dispatch)
+
+- [ ] **Step 1: Bind Q outside input**
+
+Locate the key dispatch (search `KeyCode::Char('q')` for existing hits). Add a guard:
+
+```rust
+if app.log_browser_mode
+    && !app.input.has_focus()
+    && key.code == KeyCode::Char('q')
+{
+    app.should_quit = true;
+    return;
+}
+```
+
+(`input.has_focus()` may be named differently — search the existing handlers for the equivalent `is_editing_input` predicate.)
+
+- [ ] **Step 2: Trigger `load_older_messages` on scroll-up at top**
+
+Find the chat scroll handler. On the `ScrollUp` event, after performing the scroll, if `app.log_browser_mode` and the new `scroll_offset` puts the user at the top of `messages` and `!buffer.history_exhausted`, call `app.load_older_messages(&buffer_id)`.
+
+- [ ] **Step 3: Build + tests**
+
+```bash
+. "$HOME/.cargo/env" && cargo build -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo test -p repartee --quiet 2>&1 | tail -3
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/mod.rs
+git -c user.name="kofany" -c user.email="j@dabrowski.biz" commit -m "feat(log-browser): Q to quit + scroll-up paginates"
+```
+
+---
+
+## Task 16: Final clippy + tests + push
+
+- [ ] **Step 1: Full sweep**
+
+```bash
+. "$HOME/.cargo/env" && cargo clippy -p repartee --tests --no-deps 2>&1 | tail -5
+. "$HOME/.cargo/env" && cargo test -p repartee 2>&1 | tail -3
+. "$HOME/.cargo/env" && cargo build --release -p repartee 2>&1 | tail -3
+```
+
+Required: zero new clippy warnings on touched files (pre-existing warnings on untouched files are fine).
+
+- [ ] **Step 2: Manual smoke**
+
+```bash
+# Seed a tiny log
+sqlite3 ~/.repartee/logs/messages.db <<'SQL'
+CREATE TABLE IF NOT EXISTS messages (
+  id INTEGER PRIMARY KEY,
+  timestamp INTEGER,
+  network TEXT,
+  buffer TEXT,
+  message_type TEXT,
+  nick TEXT,
+  text TEXT
+);
+INSERT INTO messages (timestamp, network, buffer, message_type, nick, text)
+VALUES
+ (1700000000, 'libera', '#test', 'message', 'ada', 'hello world'),
+ (1700000001, 'libera', '#test', 'message', 'ktk', 'hi'),
+ (1700000002, 'oftc',   '#debian','message', 'pi',  'sup');
+SQL
+```
+
+(Skip if the user's DB already has data — just `repartee l` against the live DB.)
+
+```bash
+/home/projekt/dev/repartee/target/release/repartee l
+```
+
+Verify:
+- Sidebar shows `libera` and `oftc`.
+- Active buffer auto-loads, topic shows the date range, status shows `1/N from <date>`.
+- Alt-↑/↓ navigates between log buffers.
+- `/quit` and `q` both exit cleanly.
+- `/search hello` returns the seeded line.
+- `/help` lists commands.
+- Typing plain text is rejected with the hint.
+
+- [ ] **Step 3: Push**
+
+```bash
+git push origin feat/log-browser
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+
+- ✅ §CLI — Task 10
+- ✅ §Architecture (`log_browser_mode`) — Tasks 6, 9
+- ✅ §Storage Access (`open_readonly_at`) — Task 3
+- ✅ §Sidebar Catalog — Tasks 4, 7
+- ✅ §`BufferType::Log` — Task 1
+- ✅ §Lazy Loading — Tasks 8, 13
+- ✅ §Topic Bar — Task 11
+- ✅ §Status Line — Task 12
+- ✅ §Input Bar (`/search`, `/quit`, `/help`) — Task 14
+- ✅ §Layout untouched — implicit, only render-content branches added
+- ✅ §Module Layout — files match plan File Structure table
+- ⏭ §V1.1 commands `/jump` `/grep` — explicitly deferred per spec; not in plan tasks
+
+**Type consistency:**
+
+- `App::LOG_CONN_PREFIX` declared in Task 7, referenced in Task 8 (`split_log_buffer_id`), Task 11 (topic bar `trim_start_matches`), Task 14 (`log_buffer_id_parts`). Consistent.
+- `LogDb` declared Task 5, used Tasks 7 + 8 + 14. Consistent.
+- `load_initial_messages` / `load_older_messages` defined Task 8, called Tasks 13 + 15. Consistent.
+
+**Placeholders:** none — every step contains either complete code, an exact command, or an explicit "search for X / replace with Y" instruction with the search query attached.

--- a/docs/superpowers/plans/2026-05-09-log-browser.md
+++ b/docs/superpowers/plans/2026-05-09-log-browser.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Standalone process (no fork, no IRC, no daemon link) that opens the message DB read-only via SQLite WAL, builds a sidebar of pseudo-`Connection`s + `BufferType::Log` buffers from `SELECT DISTINCT (network, buffer) FROM messages`, and lazy-paginates content via the existing `query::get_messages` API. The whole thing is gated by a single `App::log_browser_mode: bool` flag — every chat-mode entry point in `App::run` either branches on this flag or is short-circuited.
 
-**Tech Stack:** Rust 2024, ratatui 0.30, tokio (current_thread), rusqlite (existing dependency, used in read-only `mode=ro&immutable=1` URI), no new crates.
+**Tech Stack:** Rust 2024, ratatui 0.30, tokio (current_thread), rusqlite (existing dependency, used in read-only `mode=ro` URI — NOT `immutable=1`, which would block reading new WAL writes from the daemon), no new crates.
 
 **Reference spec:** `docs/superpowers/specs/2026-05-09-log-browser-design.md`.
 

--- a/docs/superpowers/specs/2026-05-09-log-browser-design.md
+++ b/docs/superpowers/specs/2026-05-09-log-browser-design.md
@@ -163,7 +163,7 @@ In log mode the input bar accepts only `/`-prefixed input. Anything else flashes
 
 | Command | Behaviour |
 |---------|-----------|
-| `/search <text>` | `storage::search_messages(db, query, Some(network), Some(buffer), 1000)` (FTS5 if plain DB; LIKE fallback if encrypted). Highlights matches in the visible buffer; `n` / `N` jump to next/previous match. |
+| `/search <text>` | FTS5 on plain DBs; on encrypted DBs falls back to fetching the active buffer through `get_messages` (decrypted in-process) and filtering case-insensitively in memory. Returns up to 1000 hits printed inline as `[N matches] timestamp <nick> text`. |
 | `/quit` | Exit log browser process. Also bound to `q` / `Q` outside input. |
 | `/help` | List of available commands in the active buffer. |
 
@@ -171,6 +171,7 @@ In log mode the input bar accepts only `/`-prefixed input. Anything else flashes
 
 | Command | Behaviour |
 |---------|-----------|
+| `/search` highlighting + `n`/`N` nav | Visible-buffer match highlighting and `n`/`N` cursor jumping. Requires per-buffer match-cursor state, scroll-to-message logic, and conditional rendering tweaks in `chat_view` — out of scope for V1; the inline match listing covers the same functional need. |
 | `/jump <YYYY-MM-DD[ HH:MM[:SS]]>` | Loads ±100 messages bracketing the closest timestamp; replaces visible window. |
 | `/grep <regex>` | In-memory filter on the visible buffer. `/grep` with no argument clears. |
 

--- a/docs/superpowers/specs/2026-05-09-log-browser-design.md
+++ b/docs/superpowers/specs/2026-05-09-log-browser-design.md
@@ -1,0 +1,239 @@
+# Log Browser Design
+
+## Overview
+
+A new `repartee l` (alias `repartee logs`) subcommand that opens a **read-only TUI log browser** over the SQLite history. Reuses the entire existing layout — topic bar, left sidebar, scrollback, status line, input bar — so users navigate logs with the same muscle memory as live chat.
+
+The log browser is a separate process, completely isolated from any running daemon. SQLite WAL mode permits concurrent reads while the daemon writes.
+
+Goals:
+
+- See full per-channel / per-query history, browseable like normal IRC buffers
+- Lazy-loaded paginated read (don't slurp 100k messages on open)
+- Zero new UI layers — sidebar groups by network, buffers per channel
+- Full encryption support (AES-256-GCM logs are decrypted in this process the same way the daemon decrypts them for backlog)
+- Standalone — works even when the daemon is offline
+
+Non-goals (explicitly out of scope, candidates for later):
+
+- Cross-network global search (separate feature; FTS already exists for that)
+- Editing / deleting log entries
+- Export to file
+- Web UI mirror (architecture allows it later, but not in this iteration)
+- Bookmarks / favorites / tagging
+
+## CLI
+
+```
+repartee l        # log browser, alias of `logs`
+repartee logs
+```
+
+- No fork. Parent process owns the terminal directly (mirrors `repartee a`).
+- No tokio runtime needed for IRC, but tokio still used for crossterm `event-stream` and the periodic tick — same `App::run` loop, gated by a flag.
+- No socket listener, no IRC connections, no autoconnect, no autosendcmd, no web server, no scripting engine load. The log browser is intentionally minimal.
+- Pre-fork config validation (current `validate_startup_files`) still runs so a typo in `config.toml` surfaces here too.
+
+## Architecture
+
+A single new flag on `App` plus a small handful of new state and rendering branches:
+
+```rust
+pub struct App {
+    // ...existing fields...
+    pub log_browser_mode: bool,
+}
+```
+
+When `true`:
+
+- `App::run` skips `start_socket_listener`, `autoload_scripts`, `start_web_server`, autoconnect.
+- IRC event dispatch is dead code (no irc_handles ever populated).
+- Sidebar source is built from the SQLite catalog instead of `config.servers` + IRC state.
+- Slash commands are filtered to a log-mode allowlist (anything else → status hint).
+
+The log browser is an alternative entry point, not a runtime mode the user toggles. Once started in log mode, you stay in log mode until exit — keeps the mental model clean.
+
+## Storage Access
+
+A new helper opens the database read-only via SQLite URI:
+
+```rust
+// storage::open_readonly(path) → Connection opened with
+// "file:<path>?mode=ro&immutable=1" so the daemon can keep writing.
+```
+
+`immutable=1` tells SQLite that the file will not change during this connection; in practice the daemon **does** still write, so we use `mode=ro` only — same effect, allows WAL reads.
+
+Encryption: when `[storage] encrypt = true` in the config, the same `[e2e]` settings load the same `Aes256Gcm` key as the daemon does in `App::new`. Without the key encrypted rows are unreadable; we surface a clear error and exit if the key cannot be derived.
+
+## Sidebar Catalog
+
+At startup, after opening the read-only DB, we run:
+
+```sql
+SELECT DISTINCT network, buffer FROM messages ORDER BY network, buffer;
+```
+
+For each row we synthesise:
+
+- One pseudo-`Connection` per distinct `network` — `should_reconnect = false`, `status = Connected`, dummy `ServerConfig`. The connection's `label` defaults to the `network` ID; if `config.servers.<id>.label` exists in the user's config file, that friendlier label is used.
+- One `Buffer` per `(network, buffer)` of new type **`BufferType::Log`** — `messages: VecDeque::new()` (filled lazily), `connection_id = network`, `name = buffer`, `topic = None`.
+
+The sidebar renders these via the existing `buffer_list::render` with no changes — networks are headers, buffers under them, sorting and grouping reuse the existing pipeline.
+
+There is no Status pseudo-buffer per network in log mode (a Status buffer in chat is the IRC server console; in log mode it has no analog). Each pseudo-network in the sidebar contains only its log buffers.
+
+## BufferType::Log
+
+A new variant:
+
+```rust
+pub enum BufferType {
+    Mentions,
+    Server,
+    Channel,
+    Query,
+    DccChat,
+    Special,
+    Shell,
+    Log,        // ← new
+}
+```
+
+Sort group: `2` (same as `Channel`). Log buffers always sit under a pseudo-network whose `connection_id` differs from any real network, so they never mix with live channels in the sidebar; the shared sort group simply means a network's log buffers list above its DCC chats / specials, the same ordering users already know. Keeping `Log` as a *distinct* enum variant from `Channel` is what suppresses the right-side nick list — `show_nicklist` already gates on `BufferType::Channel`, so Log buffers automatically render without it.
+
+## Lazy Loading
+
+```text
+INITIAL_LIMIT = 200
+PAGE_LIMIT = 200
+```
+
+When a log buffer becomes active for the first time and `messages.is_empty()`:
+
+```rust
+storage::query::get_messages(&db, network, buffer, /* before */ None, INITIAL_LIMIT, ...)
+```
+
+`get_messages` already orders DESC + reverses to ASC chronological. The 200 returned messages are inserted in order.
+
+When the user scrolls up (`scroll_offset` reaches the loaded top), we fire:
+
+```rust
+let oldest_ts = buf.messages.front().map(|m| m.timestamp.timestamp());
+storage::query::get_messages(&db, network, buffer, oldest_ts, PAGE_LIMIT, ...)
+```
+
+Returned rows are prepended. If `< PAGE_LIMIT` were returned, we mark the buffer as `history_exhausted = true` (a new field on `Buffer`, used **only** by log mode — defaults `false` and is written nowhere in chat mode).
+
+Memory cap: not enforced in V1. With 200/page even an aggressive scroll-up session loads at most a few thousand messages before reaching the start of the log; the buffer will not balloon under realistic use. If telemetry shows otherwise we can add bounded eviction.
+
+## Topic Bar
+
+Existing topic bar widget gets a new branch:
+
+```text
+📜 Log: #polska @ libera  •  12,847 lines  •  2024-08-12 → 2026-05-09
+```
+
+Computed once per buffer activation:
+
+```sql
+SELECT COUNT(*), MIN(timestamp), MAX(timestamp)
+FROM messages
+WHERE network = ? AND buffer = ?
+```
+
+Cached on the `Buffer` itself (new optional fields `log_total_lines`, `log_oldest_ts`, `log_newest_ts`) so the topic bar render doesn't requery on every frame.
+
+## Status Line
+
+```text
+log mode • libera/#polska • showing 200/12,847 from 2026-04-15 14:23  •  ↑/↓ scroll • / search • Q quit
+```
+
+The "from {timestamp}" reflects the oldest currently-loaded message — i.e. how far back the user has paged. As they scroll up and pages prepend, this value moves backward.
+
+## Input Bar (slash commands only)
+
+In log mode the input bar accepts only `/`-prefixed input. Anything else flashes a status hint and is ignored.
+
+**V1 — required:**
+
+| Command | Behaviour |
+|---------|-----------|
+| `/search <text>` | `storage::search_messages(db, query, Some(network), Some(buffer), 1000)` (FTS5 if plain DB; LIKE fallback if encrypted). Highlights matches in the visible buffer; `n` / `N` jump to next/previous match. |
+| `/quit` | Exit log browser process. Also bound to `q` / `Q` outside input. |
+| `/help` | List of available commands in the active buffer. |
+
+**V1.1 — follow-up:**
+
+| Command | Behaviour |
+|---------|-----------|
+| `/jump <YYYY-MM-DD[ HH:MM[:SS]]>` | Loads ±100 messages bracketing the closest timestamp; replaces visible window. |
+| `/grep <regex>` | In-memory filter on the visible buffer. `/grep` with no argument clears. |
+
+## Layout — Untouched
+
+```
+┌─ topic bar ─────────────────────────────────────────────────────────┐
+│ 📜 Log: #polska @ libera • 12,847 lines • 2024-08 → 2026-05         │
+├──────────┬──────────────────────────────────────────────────────────┤
+│ libera   │ <messages>                                                │
+│  #rust   │                                                           │
+│ #polska* │  ← active                                                 │
+│ ircnet   │                                                           │
+│  #pl     │                                                           │
+│ oftc     │                                                           │
+│  #debian │                                                           │
+├──────────┴──────────────────────────────────────────────────────────┤
+│ status line                                                          │
+│ /_                                                                   │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+`buffer_list`, `chat_view`, `topic_bar`, `status_line`, `input` widgets are reused without forking the renderer. New behaviour goes into the **content** they receive, not into new widgets.
+
+## Module Layout
+
+```
+src/app/log_browser.rs    NEW  — App methods used only in log_browser_mode
+                                  (build_catalog, load_initial, load_older,
+                                  cmd_search/jump/grep/help, exit handling).
+src/commands/handlers_logs.rs  NEW — log-mode command handlers; small file.
+src/state/buffer.rs       MOD  — add BufferType::Log, history_exhausted,
+                                  log_total_lines, log_oldest_ts, log_newest_ts.
+src/storage/db.rs         MOD  — add open_readonly(path) helper.
+src/storage/query.rs      MOD  — add list_networks, list_buffers,
+                                  buffer_stats (count + min/max ts).
+src/main.rs               MOD  — `repartee l` / `logs` subcommand branch.
+src/app/mod.rs            MOD  — log_browser_mode field, gating in `run`.
+src/ui/topic_bar.rs       MOD  — log-mode header.
+src/ui/status_line.rs     MOD  — log-mode line.
+```
+
+## Configuration
+
+No new TOML options for V1. Behaviour is keyboard-driven and the storage path / encryption settings are reused from the existing `[storage]` and `[e2e]` sections.
+
+## Testing Strategy
+
+| Layer | Tests |
+|-------|-------|
+| `storage::open_readonly` | opens with daemon-style `Connection` and refuses writes. |
+| `query::list_networks` / `list_buffers` | seeded DB → expected sorted lists. |
+| `query::buffer_stats` | count + min/max timestamp on synthetic rows. |
+| `App::build_log_catalog` | given a seeded DB, produces correct pseudo-connections + log buffers. |
+| `App::load_initial_messages` / `load_older_messages` | seeded buffer → chronological order, prepend semantics, `history_exhausted` flag flip. |
+| Integration smoke | `repartee l` against an empty DB shows empty sidebar and exits cleanly on Q. |
+
+Web-UI parity tests are deferred until the web mirror is built.
+
+## Out of Scope for V1
+
+- Right sidebar showing "top 20 nicks in this log" — defer.
+- Bookmark / favorite logs — defer.
+- Cross-buffer search.
+- Web UI mirror.
+- Real-time tail of currently-active channel (i.e. open log of a channel I'm currently connected to and have it auto-scroll). Possible follow-up but introduces multi-process state sync.

--- a/src/app/dcc.rs
+++ b/src/app/dcc.rs
@@ -139,6 +139,10 @@ impl App {
                         list_modes: std::collections::HashMap::new(),
                         last_speakers: Vec::new(),
                         peer_handle: None,
+                        log_total_lines: None,
+                        log_oldest_ts: None,
+                        log_newest_ts: None,
+                        history_exhausted: false,
                     });
                 }
 

--- a/src/app/dcc.rs
+++ b/src/app/dcc.rs
@@ -143,6 +143,7 @@ impl App {
                         log_oldest_ts: None,
                         log_newest_ts: None,
                         history_exhausted: false,
+                        log_initial_loaded: false,
                     });
                 }
 

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -551,6 +551,7 @@ impl App {
                 log_oldest_ts: None,
                 log_newest_ts: None,
                 history_exhausted: false,
+                log_initial_loaded: false,
             });
         }
         self.state.set_active_buffer(&query_buf_id);
@@ -718,6 +719,15 @@ impl App {
     pub(crate) fn handle_submit(&mut self, text: &str) {
         if let Some(parsed) = crate::commands::parser::parse_command(text) {
             self.execute_command_with_depth(&parsed, 0);
+        } else if self.log_browser_mode {
+            // Spec: log mode rejects plain text — there is no IRC
+            // connection to send to, and routing through
+            // `handle_plain_message` would produce the unrelated
+            // "Cannot send messages to this buffer" line.
+            crate::commands::helpers::add_local_event(
+                self,
+                "log mode: only slash commands. /help",
+            );
         } else {
             self.handle_plain_message(text);
         }

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -726,6 +726,25 @@ impl App {
             return;
         }
 
+        // Log-browser mode short-circuits the registry: the only valid
+        // verbs are `/search`, `/quit`, `/help` (plus their aliases). Any
+        // other command echoes a hint and returns. Scripts are unloaded
+        // in log mode so we skip the script emit too.
+        if self.log_browser_mode {
+            match parsed.name.as_str() {
+                "search" => crate::commands::handlers_logs::cmd_log_search(self, &parsed.args),
+                "quit" | "exit" => {
+                    crate::commands::handlers_logs::cmd_log_quit(self, &parsed.args);
+                }
+                "help" => crate::commands::handlers_logs::cmd_log_help(self, &parsed.args),
+                other => crate::commands::helpers::add_local_event(
+                    self,
+                    &format!("log mode: only /search, /quit, /help (got /{other})"),
+                ),
+            }
+            return;
+        }
+
         // Emit to scripts — they can suppress commands
         {
             use crate::scripting::api::events;

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -221,6 +221,9 @@ impl App {
             (_, KeyCode::Down) => self.input.history_down(),
             (_, KeyCode::PageUp) => {
                 self.scroll_offset = self.scroll_offset.saturating_add(10);
+                if self.log_browser_mode {
+                    self.maybe_paginate_log_buffer();
+                }
             }
             (_, KeyCode::PageDown) => {
                 self.scroll_offset = self.scroll_offset.saturating_sub(10);
@@ -241,6 +244,18 @@ impl App {
                 } else {
                     self.handle_tab();
                 }
+            }
+            // Log-browser hotkey: bare `q` / `Q` with no modifiers (other than
+            // Shift) quits the browser when the input line is empty. Mirrors
+            // weechat's `q` shortcut in `/buffer history`-style read-only views.
+            // The empty-buffer guard means typing `quit` or any text that
+            // starts with `q` still works as a normal slash command sequence.
+            (mods, KeyCode::Char('q' | 'Q'))
+                if self.log_browser_mode
+                    && self.input.value.is_empty()
+                    && (mods.is_empty() || mods == KeyModifiers::SHIFT) =>
+            {
+                self.should_quit = true;
             }
             (mods, KeyCode::Char(c)) if mods.is_empty() || mods == KeyModifiers::SHIFT => {
                 let is_highlight = self
@@ -384,6 +399,9 @@ impl App {
             MouseEventKind::ScrollUp => {
                 if regions.chat_area.is_some_and(|r| r.contains(pos)) {
                     self.scroll_offset = self.scroll_offset.saturating_add(3);
+                    if self.log_browser_mode {
+                        self.maybe_paginate_log_buffer();
+                    }
                 } else if regions.buffer_list_area.is_some_and(|r| r.contains(pos)) {
                     self.buffer_list_scroll = self.buffer_list_scroll.saturating_sub(1);
                 } else if regions.nick_list_area.is_some_and(|r| r.contains(pos)) {

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -529,6 +529,10 @@ impl App {
                 list_modes: HashMap::new(),
                 last_speakers: Vec::new(),
                 peer_handle: None,
+                log_total_lines: None,
+                log_oldest_ts: None,
+                log_newest_ts: None,
+                history_exhausted: false,
             });
         }
         self.state.set_active_buffer(&query_buf_id);

--- a/src/app/irc.rs
+++ b/src/app/irc.rs
@@ -79,6 +79,7 @@ impl App {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
         self.state.set_active_buffer(&server_buf_id);
 
@@ -396,6 +397,7 @@ impl App {
                             log_oldest_ts: None,
                             log_newest_ts: None,
                             history_exhausted: false,
+                            log_initial_loaded: false,
                         });
                     }
                 }

--- a/src/app/irc.rs
+++ b/src/app/irc.rs
@@ -75,6 +75,10 @@ impl App {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
         self.state.set_active_buffer(&server_buf_id);
 
@@ -388,6 +392,10 @@ impl App {
                             list_modes: HashMap::new(),
                             last_speakers: Vec::new(),
                             peer_handle: None,
+                            log_total_lines: None,
+                            log_oldest_ts: None,
+                            log_newest_ts: None,
+                            history_exhausted: false,
                         });
                     }
                 }

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -80,9 +80,10 @@ impl App {
 
         for net in &networks {
             let conn_id = format!("{}{net}", Self::LOG_CONN_PREFIX);
+            let net_label = label_for(net);
             self.state.add_connection(Connection {
                 id: conn_id.clone(),
-                label: label_for(net),
+                label: net_label.clone(),
                 status: ConnectionStatus::Connected,
                 nick: String::new(),
                 user_modes: String::new(),
@@ -124,6 +125,38 @@ impl App {
                 who_token_counter: 0,
                 silent_who_channels: HashSet::new(),
                 silent_banlist_channels: HashSet::new(),
+            });
+
+            // Server-type header buffer for the pseudo-network. Buffer-list
+            // rendering treats `BufferType::Server` specially — it shows
+            // the connection label and applies the `item_server` theme
+            // format, which is what makes the "libera" / "ircnet" / "oftc"
+            // headers visually pop in the sidebar instead of blending
+            // into the channel list. Mirrors the Shell synthetic
+            // connection pattern in `app::shell::ensure_shell_connection`.
+            let header_id = make_buffer_id(&conn_id, &net_label);
+            self.state.add_buffer(Buffer {
+                id: header_id,
+                connection_id: conn_id.clone(),
+                buffer_type: BufferType::Server,
+                name: net_label.clone(),
+                messages: VecDeque::new(),
+                activity: ActivityLevel::None,
+                unread_count: 0,
+                last_read: Utc::now(),
+                topic: None,
+                topic_set_by: None,
+                users: HashMap::new(),
+                modes: None,
+                mode_params: None,
+                list_modes: HashMap::new(),
+                last_speakers: Vec::new(),
+                peer_handle: None,
+                log_total_lines: None,
+                log_oldest_ts: None,
+                log_newest_ts: None,
+                history_exhausted: false,
+                log_initial_loaded: false,
             });
 
             let buffers = {
@@ -223,10 +256,10 @@ impl App {
                 let exhausted = rows.len() < INITIAL_LIMIT;
                 // Allocate fresh message ids first (mutable state borrow),
                 // then push into the buffer (separate mutable borrow).
-                let messages: Vec<_> = rows
-                    .iter()
-                    .map(|stored| stored_to_message(&mut self.state, stored))
-                    .collect();
+                // Inject day-change separators between consecutive rows
+                // whose local-time date differs — same UX as `app::backlog`
+                // and weechat/irssi log files.
+                let messages = rows_to_buffer_messages(&mut self.state, &rows);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
                     for msg in messages {
                         buffer.messages.push_back(msg);
@@ -294,17 +327,12 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < PAGE_LIMIT;
-                // Build messages first to avoid holding two mutable
-                // borrows on `self.state` simultaneously. Reverse the
-                // chronological-ascending result so we can `push_front`
-                // them in order — the buffer stays sorted.
-                let messages: Vec<_> = rows
-                    .iter()
-                    .rev()
-                    .map(|stored| stored_to_message(&mut self.state, stored))
-                    .collect();
+                // Build the chronologically-ordered batch with day
+                // separators interleaved, then prepend in reverse order
+                // so the buffer stays sorted (oldest at front).
+                let messages = rows_to_buffer_messages(&mut self.state, &rows);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
-                    for msg in messages {
+                    for msg in messages.into_iter().rev() {
                         buffer.messages.push_front(msg);
                     }
                     if exhausted {
@@ -365,6 +393,47 @@ impl App {
 /// next message. `log_msg_id` carries the `SQLite` row id as a
 /// decimal string so `load_older_messages` can build a `(timestamp,
 /// id)` composite cursor without losing same-second rows.
+/// Convert a chronological slice of stored rows into in-memory
+/// `Message`s with day-change separators interleaved. Mirrors the UX
+/// of `app::backlog::build_backlog_messages`: when consecutive rows
+/// fall on different local-time dates, a `MessageType::Event` row
+/// styled like irssi/weechat day separators (`─── Mon, 12 Aug 2024
+/// ───`) is inserted between them. Ids come from `state.message_counter`.
+fn rows_to_buffer_messages(
+    state: &mut crate::state::AppState,
+    rows: &[crate::storage::StoredMessage],
+) -> Vec<crate::state::buffer::Message> {
+    use crate::state::buffer::{Message, MessageType};
+    use chrono::{Local, TimeZone};
+    let mut out: Vec<Message> = Vec::with_capacity(rows.len() + 4);
+    let mut last_date: Option<chrono::NaiveDate> = None;
+    for stored in rows {
+        let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0)
+            .unwrap_or_else(Utc::now);
+        let local_date = Local.from_utc_datetime(&ts.naive_utc()).date_naive();
+        if last_date.is_none_or(|d| d != local_date) {
+            let sep_text = crate::app::backlog::format_date_separator(local_date);
+            out.push(Message {
+                id: state.next_message_id(),
+                timestamp: ts,
+                message_type: MessageType::Event,
+                nick: None,
+                nick_mode: None,
+                text: sep_text.clone(),
+                highlight: false,
+                event_key: Some("date_separator".to_string()),
+                event_params: Some(vec![sep_text]),
+                log_msg_id: None,
+                log_ref_id: None,
+                tags: None,
+            });
+        }
+        last_date = Some(local_date);
+        out.push(stored_to_message(state, stored));
+    }
+    out
+}
+
 fn stored_to_message(
     state: &mut crate::state::AppState,
     stored: &crate::storage::StoredMessage,

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -159,4 +159,160 @@ impl App {
         }
         Ok(())
     }
+
+    /// Load the most recent messages for `buffer_id` into its in-memory
+    /// `messages` deque. Idempotent: a buffer that already has messages
+    /// is skipped, so this can be called every tick from the main loop
+    /// while a log buffer is active.
+    ///
+    /// Also caches `(line_count, oldest_ts, newest_ts)` on the buffer so
+    /// the topic-bar render doesn't requery on every frame.
+    pub fn load_initial_messages(&mut self, buffer_id: &str) {
+        const INITIAL_LIMIT: usize = 200;
+        let already_loaded = self
+            .state
+            .buffers
+            .get(buffer_id)
+            .is_some_and(|b| !b.messages.is_empty());
+        if already_loaded {
+            return;
+        }
+        let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else {
+            return;
+        };
+
+        // Cache stats first, even when there are zero messages — the
+        // topic bar should show 0/range= empty for an empty buffer.
+        let stats_result = self
+            .log_db
+            .as_ref()
+            .and_then(|d| d.db.lock().ok().map(|db| crate::storage::query::buffer_stats(&db, &net, &buf)));
+        if let Some(Ok(Some((count, oldest, newest)))) = stats_result
+            && let Some(buffer) = self.state.buffers.get_mut(buffer_id)
+        {
+            buffer.log_total_lines = Some(count);
+            buffer.log_oldest_ts = Some(oldest);
+            buffer.log_newest_ts = Some(newest);
+        }
+
+        let Some(log_db) = &self.log_db else { return };
+        let rows_result = {
+            let Ok(db) = log_db.db.lock() else { return };
+            crate::storage::query::get_messages(
+                &db,
+                &net,
+                &buf,
+                None,
+                INITIAL_LIMIT,
+                log_db.crypto_key.is_some(),
+                log_db.crypto_key.as_ref(),
+            )
+        };
+        match rows_result {
+            Ok(rows) => {
+                let exhausted = rows.len() < INITIAL_LIMIT;
+                if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
+                    for stored in rows {
+                        buffer.messages.push_back(stored_to_message(&stored));
+                    }
+                    buffer.history_exhausted = exhausted;
+                }
+            }
+            Err(e) => tracing::warn!(%buffer_id, "log load_initial failed: {e}"),
+        }
+    }
+
+    /// Prepend up to `PAGE_LIMIT` messages older than the oldest currently
+    /// loaded message. Sets `history_exhausted` when fewer rows are
+    /// returned than requested. No-op when the buffer is already
+    /// exhausted; falls back to `load_initial_messages` when called on
+    /// an empty buffer.
+    pub fn load_older_messages(&mut self, buffer_id: &str) {
+        const PAGE_LIMIT: usize = 200;
+        let Some(buffer) = self.state.buffers.get(buffer_id) else {
+            return;
+        };
+        if buffer.history_exhausted {
+            return;
+        }
+        let Some(oldest_msg) = buffer.messages.front() else {
+            self.load_initial_messages(buffer_id);
+            return;
+        };
+        let oldest_ts = oldest_msg.timestamp.timestamp();
+        let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else {
+            return;
+        };
+        let Some(log_db) = &self.log_db else { return };
+        let rows_result = {
+            let Ok(db) = log_db.db.lock() else { return };
+            crate::storage::query::get_messages(
+                &db,
+                &net,
+                &buf,
+                Some(oldest_ts),
+                PAGE_LIMIT,
+                log_db.crypto_key.is_some(),
+                log_db.crypto_key.as_ref(),
+            )
+        };
+        match rows_result {
+            Ok(rows) => {
+                let exhausted = rows.len() < PAGE_LIMIT;
+                if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
+                    // get_messages returns chronological ascending — push
+                    // them onto the front in reverse order so the buffer
+                    // stays sorted.
+                    for stored in rows.into_iter().rev() {
+                        buffer.messages.push_front(stored_to_message(&stored));
+                    }
+                    if exhausted {
+                        buffer.history_exhausted = true;
+                    }
+                }
+            }
+            Err(e) => tracing::warn!(%buffer_id, "log load_older failed: {e}"),
+        }
+    }
+
+    /// Split a `BufferType::Log` buffer id (`_log_<network>/<buffer>`)
+    /// into `(network, buffer_name)`. Returns `None` for non-log
+    /// buffers — the connection_id prefix is the discriminator.
+    pub(crate) fn split_log_buffer_id(&self, buffer_id: &str) -> Option<(String, String)> {
+        let buffer = self.state.buffers.get(buffer_id)?;
+        let net = buffer
+            .connection_id
+            .strip_prefix(Self::LOG_CONN_PREFIX)?
+            .to_string();
+        Some((net, buffer.name.clone()))
+    }
+}
+
+/// Convert a row read from `messages` into the in-memory `Message`
+/// struct used by the buffer pipeline. Mirrors `app::backlog`'s
+/// conversion but lives here because the log browser doesn't share
+/// `App.storage` (which is `None` in log mode).
+fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::buffer::Message {
+    use crate::state::buffer::{Message, MessageType};
+    let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0).unwrap_or_else(Utc::now);
+    let msg_type = match stored.msg_type.as_str() {
+        "action" => MessageType::Action,
+        "notice" => MessageType::Notice,
+        "event" => MessageType::Event,
+        _ => MessageType::Message,
+    };
+    Message {
+        id: 0,
+        timestamp: ts,
+        message_type: msg_type,
+        nick: stored.nick.clone(),
+        nick_mode: None,
+        text: stored.text.clone(),
+        highlight: stored.highlight,
+        event_key: stored.event_key.clone(),
+        event_params: None,
+        log_msg_id: None,
+        log_ref_id: None,
+        tags: None,
+    }
 }

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -43,6 +43,13 @@ impl App {
         app.state.previous_buffer_id = None;
 
         app.build_log_catalog()?;
+        // Eager-load the initial buffer's history so the user sees logs
+        // even if they type a slash command before the first 1-Hz tick.
+        // The tick still calls this — `log_initial_loaded` makes it a
+        // no-op the second time around.
+        if let Some(active_id) = app.state.active_buffer_id.clone() {
+            app.load_initial_messages(&active_id);
+        }
         Ok(app)
     }
 
@@ -254,16 +261,24 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < INITIAL_LIMIT;
-                // Allocate fresh message ids first (mutable state borrow),
-                // then push into the buffer (separate mutable borrow).
-                // Inject day-change separators between consecutive rows
-                // whose local-time date differs — same UX as `app::backlog`
-                // and weechat/irssi log files. `None` for the initial
-                // load: the buffer is empty so no separator can collide.
+                // Build messages first (mutable state borrow), then
+                // push into the buffer (separate mutable borrow).
                 let messages = rows_to_buffer_messages(&mut self.state, &rows, None);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
-                    for msg in messages {
-                        buffer.messages.push_back(msg);
+                    if buffer.messages.is_empty() {
+                        for msg in messages {
+                            buffer.messages.push_back(msg);
+                        }
+                    } else {
+                        // Buffer already contains local events — `/help`
+                        // output, `/search` errors, or the slash-only
+                        // hint were emitted before this first lazy
+                        // load fired. Prepend the actual log so
+                        // history reads chronologically and the
+                        // command output stays at the bottom.
+                        for msg in messages.into_iter().rev() {
+                            buffer.messages.push_front(msg);
+                        }
                     }
                     buffer.history_exhausted = exhausted;
                     buffer.log_initial_loaded = true;
@@ -341,30 +356,35 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < PAGE_LIMIT;
-                // Look up the local date of the existing oldest real
-                // message in the buffer (skipping synthetic separators
-                // again — they don't count as a "real" date marker).
-                // Pass it to `rows_to_buffer_messages` so the helper
-                // suppresses a separator for that date when it appears
-                // at the boundary, avoiding the `[sep_Aug12, … ,
-                // sep_Aug12, …]` duplicate after prepend.
-                let existing_first_date = self
-                    .state
-                    .buffers
-                    .get(buffer_id)
-                    .and_then(|b| {
-                        b.messages
-                            .iter()
-                            .find(|m| m.log_msg_id.is_some())
-                            .map(|m| {
-                                use chrono::TimeZone as _;
-                                chrono::Local
-                                    .from_utc_datetime(&m.timestamp.naive_utc())
-                                    .date_naive()
-                            })
-                    });
-                let messages =
-                    rows_to_buffer_messages(&mut self.state, &rows, existing_first_date);
+                // If the newest row in this batch shares its local date
+                // with the existing buffer head separator, drop that
+                // separator before prepending. The new batch will emit
+                // its own separator for that date in the correct
+                // position (above the new oldest message), avoiding the
+                // earlier mistake of leaving messages above their
+                // separator.
+                let last_new_date = rows.last().map(|r| {
+                    use chrono::TimeZone as _;
+                    let ts = chrono::DateTime::<Utc>::from_timestamp(r.timestamp, 0)
+                        .unwrap_or_else(Utc::now);
+                    chrono::Local
+                        .from_utc_datetime(&ts.naive_utc())
+                        .date_naive()
+                });
+                if let Some(date) = last_new_date
+                    && let Some(buffer) = self.state.buffers.get_mut(buffer_id)
+                    && let Some(first) = buffer.messages.front()
+                    && first.event_key.as_deref() == Some("date_separator")
+                {
+                    use chrono::TimeZone as _;
+                    let first_date = chrono::Local
+                        .from_utc_datetime(&first.timestamp.naive_utc())
+                        .date_naive();
+                    if first_date == date {
+                        buffer.messages.pop_front();
+                    }
+                }
+                let messages = rows_to_buffer_messages(&mut self.state, &rows, None);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
                     for msg in messages.into_iter().rev() {
                         buffer.messages.push_front(msg);
@@ -379,10 +399,18 @@ impl App {
     }
 
     /// Split a `BufferType::Log` buffer id (`_log_<network>/<buffer>`)
-    /// into `(network, buffer_name)`. Returns `None` for non-log
-    /// buffers — the `connection_id` prefix is the discriminator.
+    /// into `(network, buffer_name)`. Returns `None` for any buffer
+    /// that isn't a log — the pseudo-network header rendered as a
+    /// `BufferType::Server` row shares the `_log_` `connection_id`
+    /// prefix but isn't a real log buffer; treating it as one would
+    /// fire `/search` against a buffer name that's actually the
+    /// network's friendly label and return zero hits, plus tip the
+    /// status line into "0/0 lines" instead of leaving it alone.
     pub(crate) fn split_log_buffer_id(&self, buffer_id: &str) -> Option<(String, String)> {
         let buffer = self.state.buffers.get(buffer_id)?;
+        if buffer.buffer_type != BufferType::Log {
+            return None;
+        }
         let net = buffer
             .connection_id
             .strip_prefix(Self::LOG_CONN_PREFIX)?
@@ -434,17 +462,13 @@ impl App {
 /// styled like irssi/weechat day separators (`─── Mon, 12 Aug 2024
 /// ───`) is inserted between them. Ids come from `state.message_counter`.
 ///
-/// `existing_first_date` is the local date of the first real (non-
-/// synthetic) message already in the buffer when prepending. Pass
-/// `None` for the initial load. When the rightmost rows in `rows`
-/// share that date, the separator that would otherwise be emitted
-/// for that date is skipped — the buffer already has one, and
-/// emitting another would produce a duplicate `─── Aug 12 ───`
-/// pair after a `load_older_messages` prepend.
+/// The caller is responsible for stripping any leading separator from
+/// the existing buffer that would duplicate the first separator
+/// produced here — see `load_older_messages` for the prepend dance.
 fn rows_to_buffer_messages(
     state: &mut crate::state::AppState,
     rows: &[crate::storage::StoredMessage],
-    existing_first_date: Option<chrono::NaiveDate>,
+    _unused: Option<chrono::NaiveDate>,
 ) -> Vec<crate::state::buffer::Message> {
     use crate::state::buffer::{Message, MessageType};
     use chrono::{Local, TimeZone};
@@ -454,9 +478,7 @@ fn rows_to_buffer_messages(
         let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0)
             .unwrap_or_else(Utc::now);
         let local_date = Local.from_utc_datetime(&ts.naive_utc()).date_naive();
-        let day_changed = last_date.is_none_or(|d| d != local_date);
-        let would_duplicate = existing_first_date == Some(local_date);
-        if day_changed && !would_duplicate {
+        if last_date.is_none_or(|d| d != local_date) {
             let sep_text = crate::app::backlog::format_date_separator(local_date);
             out.push(Message {
                 id: state.next_message_id(),

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -21,19 +21,22 @@ impl App {
     pub const LOG_CONN_PREFIX: &'static str = "_log_";
 
     /// Build an `App` instance configured for the read-only log browser.
-    /// No IRC, no scripts, no web server, no socket listener — just a
-    /// `SQLite` connection backing a sidebar built from the message log.
+    /// No IRC, no scripts, no web server, no socket listener, no
+    /// `Storage::init` (which would open the DB writeable and run
+    /// retention purge) — just a read-only `SQLite` connection backing
+    /// a sidebar built from the message log.
     pub fn new_log_browser() -> Result<Self> {
-        let mut app = Self::new()?;
+        let mut app = Self::new_with_mode(true)?;
         app.log_browser_mode = true;
 
         let log_db = crate::storage::load_log_db(&app.config.logging)
             .map_err(|e| eyre!("{e}"))?;
         app.log_db = Some(log_db);
 
-        // Wipe state populated by the chat-mode `App::new` (default
-        // Status buffer, any state derived from `[servers]`) so
-        // `build_log_catalog` sees a clean sidebar.
+        // `new_with_mode(true)` does not create any default buffers,
+        // but `state.connections` may still contain whatever the
+        // chat-mode default-init leaves behind. Clear before catalog
+        // build so the sidebar reflects the SQLite history only.
         app.state.connections.clear();
         app.state.buffers.clear();
         app.state.active_buffer_id = None;
@@ -154,6 +157,7 @@ impl App {
                     log_oldest_ts: None,
                     log_newest_ts: None,
                     history_exhausted: false,
+                    log_initial_loaded: false,
                 });
             }
         }
@@ -165,9 +169,11 @@ impl App {
     }
 
     /// Load the most recent messages for `buffer_id` into its in-memory
-    /// `messages` deque. Idempotent: a buffer that already has messages
-    /// is skipped, so this can be called every tick from the main loop
-    /// while a log buffer is active.
+    /// `messages` deque. Idempotent: gated on the explicit
+    /// `log_initial_loaded` flag (NOT on `messages.is_empty()`) — the
+    /// buffer may already contain `add_local_event` rows from `/help`,
+    /// `/search` errors, or the slash-command rejection hint, which
+    /// would otherwise hide the real history forever.
     ///
     /// Also caches `(line_count, oldest_ts, newest_ts)` on the buffer so
     /// the topic-bar render doesn't requery on every frame.
@@ -177,7 +183,7 @@ impl App {
             .state
             .buffers
             .get(buffer_id)
-            .is_some_and(|b| !b.messages.is_empty());
+            .is_some_and(|b| b.log_initial_loaded);
         if already_loaded {
             return;
         }
@@ -215,14 +221,28 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < INITIAL_LIMIT;
+                // Allocate fresh message ids first (mutable state borrow),
+                // then push into the buffer (separate mutable borrow).
+                let messages: Vec<_> = rows
+                    .iter()
+                    .map(|stored| stored_to_message(&mut self.state, stored))
+                    .collect();
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
-                    for stored in rows {
-                        buffer.messages.push_back(stored_to_message(&stored));
+                    for msg in messages {
+                        buffer.messages.push_back(msg);
                     }
                     buffer.history_exhausted = exhausted;
+                    buffer.log_initial_loaded = true;
                 }
             }
-            Err(e) => tracing::warn!(%buffer_id, "log load_initial failed: {e}"),
+            Err(e) => {
+                tracing::warn!(%buffer_id, "log load_initial failed: {e}");
+                // Mark loaded anyway — retrying on every tick would
+                // hammer the DB with the same broken query.
+                if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
+                    buffer.log_initial_loaded = true;
+                }
+            }
         }
     }
 
@@ -274,12 +294,18 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < PAGE_LIMIT;
+                // Build messages first to avoid holding two mutable
+                // borrows on `self.state` simultaneously. Reverse the
+                // chronological-ascending result so we can `push_front`
+                // them in order — the buffer stays sorted.
+                let messages: Vec<_> = rows
+                    .iter()
+                    .rev()
+                    .map(|stored| stored_to_message(&mut self.state, stored))
+                    .collect();
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
-                    // get_messages returns chronological ascending — push
-                    // them onto the front in reverse order so the buffer
-                    // stays sorted.
-                    for stored in rows.into_iter().rev() {
-                        buffer.messages.push_front(stored_to_message(&stored));
+                    for msg in messages {
+                        buffer.messages.push_front(msg);
                     }
                     if exhausted {
                         buffer.history_exhausted = true;
@@ -334,10 +360,15 @@ impl App {
 /// conversion but lives here because the log browser doesn't share
 /// `App.storage` (which is `None` in log mode).
 ///
-/// `log_msg_id` carries the `SQLite` row id as a decimal string so
-/// `load_older_messages` can build a `(timestamp, id)` composite
-/// cursor and not lose rows that share a second.
-fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::buffer::Message {
+/// `id` is taken from the live `state.message_counter` — never `0`,
+/// which would collide with web-snapshot / session diffing on the
+/// next message. `log_msg_id` carries the `SQLite` row id as a
+/// decimal string so `load_older_messages` can build a `(timestamp,
+/// id)` composite cursor without losing same-second rows.
+fn stored_to_message(
+    state: &mut crate::state::AppState,
+    stored: &crate::storage::StoredMessage,
+) -> crate::state::buffer::Message {
     use crate::state::buffer::{Message, MessageType};
     let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0).unwrap_or_else(Utc::now);
     let msg_type = match stored.msg_type.as_str() {
@@ -348,7 +379,7 @@ fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::bu
         _ => MessageType::Message,
     };
     Message {
-        id: 0,
+        id: state.next_message_id(),
         timestamp: ts,
         message_type: msg_type,
         nick: stored.nick.clone(),

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -258,8 +258,9 @@ impl App {
                 // then push into the buffer (separate mutable borrow).
                 // Inject day-change separators between consecutive rows
                 // whose local-time date differs — same UX as `app::backlog`
-                // and weechat/irssi log files.
-                let messages = rows_to_buffer_messages(&mut self.state, &rows);
+                // and weechat/irssi log files. `None` for the initial
+                // load: the buffer is empty so no separator can collide.
+                let messages = rows_to_buffer_messages(&mut self.state, &rows, None);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
                     for msg in messages {
                         buffer.messages.push_back(msg);
@@ -340,10 +341,30 @@ impl App {
         match rows_result {
             Ok(rows) => {
                 let exhausted = rows.len() < PAGE_LIMIT;
-                // Build the chronologically-ordered batch with day
-                // separators interleaved, then prepend in reverse order
-                // so the buffer stays sorted (oldest at front).
-                let messages = rows_to_buffer_messages(&mut self.state, &rows);
+                // Look up the local date of the existing oldest real
+                // message in the buffer (skipping synthetic separators
+                // again — they don't count as a "real" date marker).
+                // Pass it to `rows_to_buffer_messages` so the helper
+                // suppresses a separator for that date when it appears
+                // at the boundary, avoiding the `[sep_Aug12, … ,
+                // sep_Aug12, …]` duplicate after prepend.
+                let existing_first_date = self
+                    .state
+                    .buffers
+                    .get(buffer_id)
+                    .and_then(|b| {
+                        b.messages
+                            .iter()
+                            .find(|m| m.log_msg_id.is_some())
+                            .map(|m| {
+                                use chrono::TimeZone as _;
+                                chrono::Local
+                                    .from_utc_datetime(&m.timestamp.naive_utc())
+                                    .date_naive()
+                            })
+                    });
+                let messages =
+                    rows_to_buffer_messages(&mut self.state, &rows, existing_first_date);
                 if let Some(buffer) = self.state.buffers.get_mut(buffer_id) {
                     for msg in messages.into_iter().rev() {
                         buffer.messages.push_front(msg);
@@ -412,9 +433,18 @@ impl App {
 /// fall on different local-time dates, a `MessageType::Event` row
 /// styled like irssi/weechat day separators (`─── Mon, 12 Aug 2024
 /// ───`) is inserted between them. Ids come from `state.message_counter`.
+///
+/// `existing_first_date` is the local date of the first real (non-
+/// synthetic) message already in the buffer when prepending. Pass
+/// `None` for the initial load. When the rightmost rows in `rows`
+/// share that date, the separator that would otherwise be emitted
+/// for that date is skipped — the buffer already has one, and
+/// emitting another would produce a duplicate `─── Aug 12 ───`
+/// pair after a `load_older_messages` prepend.
 fn rows_to_buffer_messages(
     state: &mut crate::state::AppState,
     rows: &[crate::storage::StoredMessage],
+    existing_first_date: Option<chrono::NaiveDate>,
 ) -> Vec<crate::state::buffer::Message> {
     use crate::state::buffer::{Message, MessageType};
     use chrono::{Local, TimeZone};
@@ -424,7 +454,9 @@ fn rows_to_buffer_messages(
         let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0)
             .unwrap_or_else(Utc::now);
         let local_date = Local.from_utc_datetime(&ts.naive_utc()).date_naive();
-        if last_date.is_none_or(|d| d != local_date) {
+        let day_changed = last_date.is_none_or(|d| d != local_date);
+        let would_duplicate = existing_first_date == Some(local_date);
+        if day_changed && !would_duplicate {
             let sep_text = crate::app::backlog::format_date_separator(local_date);
             out.push(Message {
                 id: state.next_message_id(),

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -202,7 +202,7 @@ impl App {
         let Some(log_db) = &self.log_db else { return };
         let rows_result = {
             let Ok(db) = log_db.db.lock() else { return };
-            crate::storage::query::get_messages(
+            crate::storage::query::get_messages_paginated(
                 &db,
                 &net,
                 &buf,
@@ -244,17 +244,28 @@ impl App {
             return;
         };
         let oldest_ts = oldest_msg.timestamp.timestamp();
+        // `log_msg_id` is the SQLite row id (set in `stored_to_message`).
+        // Composite cursor `(timestamp, id)` lets us page through rows
+        // that share a second without losing any. If the id is missing
+        // for some reason (shouldn't happen for log-mode rows) we fall
+        // back to a strict timestamp cursor — one second of duplicates
+        // may be lost but the page still advances.
+        let oldest_id = oldest_msg
+            .log_msg_id
+            .as_ref()
+            .and_then(|s| s.parse::<i64>().ok());
+        let cursor = oldest_id.map(|id| (oldest_ts, id));
         let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else {
             return;
         };
         let Some(log_db) = &self.log_db else { return };
         let rows_result = {
             let Ok(db) = log_db.db.lock() else { return };
-            crate::storage::query::get_messages(
+            crate::storage::query::get_messages_paginated(
                 &db,
                 &net,
                 &buf,
-                Some(oldest_ts),
+                cursor,
                 PAGE_LIMIT,
                 log_db.crypto_key.is_some(),
                 log_db.crypto_key.as_ref(),
@@ -322,6 +333,10 @@ impl App {
 /// struct used by the buffer pipeline. Mirrors `app::backlog`'s
 /// conversion but lives here because the log browser doesn't share
 /// `App.storage` (which is `None` in log mode).
+///
+/// `log_msg_id` carries the `SQLite` row id as a decimal string so
+/// `load_older_messages` can build a `(timestamp, id)` composite
+/// cursor and not lose rows that share a second.
 fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::buffer::Message {
     use crate::state::buffer::{Message, MessageType};
     let ts = chrono::DateTime::<Utc>::from_timestamp(stored.timestamp, 0).unwrap_or_else(Utc::now);
@@ -329,6 +344,7 @@ fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::bu
         "action" => MessageType::Action,
         "notice" => MessageType::Notice,
         "event" => MessageType::Event,
+        "mention_log" => MessageType::MentionLog,
         _ => MessageType::Message,
     };
     Message {
@@ -341,7 +357,7 @@ fn stored_to_message(stored: &crate::storage::StoredMessage) -> crate::state::bu
         highlight: stored.highlight,
         event_key: stored.event_key.clone(),
         event_params: None,
-        log_msg_id: None,
+        log_msg_id: Some(stored.id.to_string()),
         log_ref_id: None,
         tags: None,
     }

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -27,7 +27,7 @@ impl App {
     /// a sidebar built from the message log.
     pub fn new_log_browser() -> Result<Self> {
         let mut app = Self::new_with_mode(true)?;
-        app.log_browser_mode = true;
+        // `new_with_mode(true)` already sets `log_browser_mode = true`.
 
         let log_db = crate::storage::load_log_db(&app.config.logging)
             .map_err(|e| eyre!("{e}"))?;
@@ -292,22 +292,35 @@ impl App {
         if buffer.history_exhausted {
             return;
         }
-        let Some(oldest_msg) = buffer.messages.front() else {
+        // Skip synthetic rows — day separators (`event_key =
+        // "date_separator"`) carry `log_msg_id: None` because they
+        // aren't real DB rows. Using one as the pagination anchor
+        // would collapse the cursor to `None`, fetching the *newest*
+        // page again and producing duplicate prepends. Walk forward
+        // until we find a row that came from `stored_to_message`.
+        let Some(oldest_msg) = buffer
+            .messages
+            .iter()
+            .find(|m| m.log_msg_id.is_some())
+        else {
             self.load_initial_messages(buffer_id);
             return;
         };
         let oldest_ts = oldest_msg.timestamp.timestamp();
         // `log_msg_id` is the SQLite row id (set in `stored_to_message`).
         // Composite cursor `(timestamp, id)` lets us page through rows
-        // that share a second without losing any. If the id is missing
-        // for some reason (shouldn't happen for log-mode rows) we fall
-        // back to a strict timestamp cursor — one second of duplicates
-        // may be lost but the page still advances.
-        let oldest_id = oldest_msg
+        // that share a second without losing any.
+        let Some(oldest_id) = oldest_msg
             .log_msg_id
             .as_ref()
-            .and_then(|s| s.parse::<i64>().ok());
-        let cursor = oldest_id.map(|id| (oldest_ts, id));
+            .and_then(|s| s.parse::<i64>().ok())
+        else {
+            // Defensive: every `stored_to_message` row sets a numeric
+            // `log_msg_id`. If parsing fails we'd fetch the newest page
+            // again, so bail.
+            return;
+        };
+        let cursor = Some((oldest_ts, oldest_id));
         let Some((net, buf)) = self.split_log_buffer_id(buffer_id) else {
             return;
         };

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -1,0 +1,162 @@
+//! Log-browser-only methods on `App`. Only invoked when
+//! `log_browser_mode == true`. Keeps the chat-mode call sites in
+//! `app/mod.rs` free of log-mode branches.
+
+use std::collections::{HashMap, HashSet, VecDeque};
+
+use chrono::Utc;
+use color_eyre::eyre::{Result, eyre};
+
+use crate::config;
+use crate::state::buffer::{ActivityLevel, Buffer, BufferType, make_buffer_id};
+use crate::state::connection::{Connection, ConnectionStatus};
+
+use super::App;
+
+impl App {
+    /// Connection ID prefix used for log-mode pseudo-networks. Distinct
+    /// from any real network identifier (which the user picks in their
+    /// config TOML) so live and log buffers never collide on
+    /// `make_buffer_id`.
+    pub const LOG_CONN_PREFIX: &'static str = "_log_";
+
+    /// Build an `App` instance configured for the read-only log browser.
+    /// No IRC, no scripts, no web server, no socket listener — just a
+    /// SQLite connection backing a sidebar built from the message log.
+    pub fn new_log_browser() -> Result<Self> {
+        let mut app = Self::new()?;
+        app.log_browser_mode = true;
+
+        let log_db = crate::storage::load_log_db(&app.config.logging)
+            .map_err(|e| eyre!("{e}"))?;
+        app.log_db = Some(log_db);
+
+        // Wipe state populated by the chat-mode `App::new` (default
+        // Status buffer, any state derived from `[servers]`) so
+        // `build_log_catalog` sees a clean sidebar.
+        app.state.connections.clear();
+        app.state.buffers.clear();
+        app.state.active_buffer_id = None;
+        app.state.previous_buffer_id = None;
+
+        app.build_log_catalog()?;
+        Ok(app)
+    }
+
+    /// Populate `state.connections` and `state.buffers` from the distinct
+    /// `(network, buffer)` pairs in the log database. Each network
+    /// becomes a synthetic `Connection`, each buffer a `BufferType::Log`
+    /// placeholder with empty `messages` (filled lazily when first
+    /// activated).
+    pub fn build_log_catalog(&mut self) -> Result<()> {
+        let log_db = self
+            .log_db
+            .as_ref()
+            .ok_or_else(|| eyre!("log catalog requires log_db"))?;
+        let networks = {
+            let db = log_db.db.lock().expect("log db poisoned");
+            crate::storage::query::list_networks(&db)
+                .map_err(|e| eyre!("list_networks: {e}"))?
+        };
+
+        // Look up friendly labels from the user's chat config when present
+        // ("libera" -> "Libera Chat" if they configured a server with
+        // that id). Falls back to the network id verbatim.
+        let label_for = |net: &str| -> String {
+            self.config
+                .servers
+                .get(net)
+                .map_or_else(|| net.to_string(), |c| c.label.clone())
+        };
+
+        let mut first_buffer_id: Option<String> = None;
+
+        for net in &networks {
+            let conn_id = format!("{}{net}", Self::LOG_CONN_PREFIX);
+            self.state.add_connection(Connection {
+                id: conn_id.clone(),
+                label: label_for(net),
+                status: ConnectionStatus::Connected,
+                nick: String::new(),
+                user_modes: String::new(),
+                isupport: HashMap::new(),
+                isupport_parsed: crate::irc::isupport::Isupport::new(),
+                error: None,
+                lag: None,
+                lag_pending: false,
+                reconnect_attempts: 0,
+                reconnect_delay_secs: 0,
+                next_reconnect: None,
+                should_reconnect: false,
+                joined_channels: Vec::new(),
+                origin_config: config::ServerConfig {
+                    label: String::new(),
+                    address: String::new(),
+                    port: 0,
+                    tls: false,
+                    tls_verify: true,
+                    autoconnect: false,
+                    channels: vec![],
+                    nick: None,
+                    username: None,
+                    realname: None,
+                    password: None,
+                    sasl_user: None,
+                    sasl_pass: None,
+                    bind_ip: None,
+                    encoding: None,
+                    auto_reconnect: Some(false),
+                    reconnect_delay: None,
+                    reconnect_max_retries: None,
+                    autosendcmd: None,
+                    sasl_mechanism: None,
+                    client_cert_path: None,
+                },
+                local_ip: None,
+                enabled_caps: HashSet::new(),
+                who_token_counter: 0,
+                silent_who_channels: HashSet::new(),
+                silent_banlist_channels: HashSet::new(),
+            });
+
+            let buffers = {
+                let db = log_db.db.lock().expect("log db poisoned");
+                crate::storage::query::list_buffers_for_network(&db, net)
+                    .map_err(|e| eyre!("list_buffers_for_network: {e}"))?
+            };
+            for buf in buffers {
+                let buf_id = make_buffer_id(&conn_id, &buf);
+                if first_buffer_id.is_none() {
+                    first_buffer_id = Some(buf_id.clone());
+                }
+                self.state.add_buffer(Buffer {
+                    id: buf_id,
+                    connection_id: conn_id.clone(),
+                    buffer_type: BufferType::Log,
+                    name: buf.clone(),
+                    messages: VecDeque::new(),
+                    activity: ActivityLevel::None,
+                    unread_count: 0,
+                    last_read: Utc::now(),
+                    topic: None,
+                    topic_set_by: None,
+                    users: HashMap::new(),
+                    modes: None,
+                    mode_params: None,
+                    list_modes: HashMap::new(),
+                    last_speakers: Vec::new(),
+                    peer_handle: None,
+                    log_total_lines: None,
+                    log_oldest_ts: None,
+                    log_newest_ts: None,
+                    history_exhausted: false,
+                });
+            }
+        }
+
+        if let Some(id) = first_buffer_id {
+            self.state.set_active_buffer(&id);
+        }
+        Ok(())
+    }
+}

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -22,7 +22,7 @@ impl App {
 
     /// Build an `App` instance configured for the read-only log browser.
     /// No IRC, no scripts, no web server, no socket listener — just a
-    /// SQLite connection backing a sidebar built from the message log.
+    /// `SQLite` connection backing a sidebar built from the message log.
     pub fn new_log_browser() -> Result<Self> {
         let mut app = Self::new()?;
         app.log_browser_mode = true;
@@ -48,6 +48,10 @@ impl App {
     /// becomes a synthetic `Connection`, each buffer a `BufferType::Log`
     /// placeholder with empty `messages` (filled lazily when first
     /// activated).
+    #[expect(
+        clippy::too_many_lines,
+        reason = "flat sidebar bootstrap; splitting helps no one"
+    )]
     pub fn build_log_catalog(&mut self) -> Result<()> {
         let log_db = self
             .log_db
@@ -277,7 +281,7 @@ impl App {
 
     /// Split a `BufferType::Log` buffer id (`_log_<network>/<buffer>`)
     /// into `(network, buffer_name)`. Returns `None` for non-log
-    /// buffers — the connection_id prefix is the discriminator.
+    /// buffers — the `connection_id` prefix is the discriminator.
     pub(crate) fn split_log_buffer_id(&self, buffer_id: &str) -> Option<(String, String)> {
         let buffer = self.state.buffers.get(buffer_id)?;
         let net = buffer
@@ -289,14 +293,14 @@ impl App {
 
     /// Trigger `load_older_messages` for the active log buffer if the
     /// user has scrolled close enough to the top to want more history.
-    /// Called from the scroll-up code paths (PageUp, mouse wheel) so the
-    /// log paginates incrementally without an explicit "fetch more"
+    /// Called from the scroll-up code paths (`PageUp`, mouse wheel) so
+    /// the log paginates incrementally without an explicit "fetch more"
     /// gesture.
     ///
-    /// Threshold: trigger when `scroll_offset` is within 50 lines of the
-    /// loaded top — i.e. the next handful of PageUps would otherwise hit
-    /// the boundary. Idempotent: `load_older_messages` already early-
-    /// returns when `history_exhausted` is set.
+    /// Threshold: trigger when `scroll_offset` is within 50 lines of
+    /// the loaded top — i.e. the next handful of `PageUp`s would
+    /// otherwise hit the boundary. Idempotent: `load_older_messages`
+    /// already early-returns when `history_exhausted` is set.
     pub(crate) fn maybe_paginate_log_buffer(&mut self) {
         let Some(active_id) = self.state.active_buffer_id.clone() else {
             return;

--- a/src/app/log_browser.rs
+++ b/src/app/log_browser.rs
@@ -286,6 +286,32 @@ impl App {
             .to_string();
         Some((net, buffer.name.clone()))
     }
+
+    /// Trigger `load_older_messages` for the active log buffer if the
+    /// user has scrolled close enough to the top to want more history.
+    /// Called from the scroll-up code paths (PageUp, mouse wheel) so the
+    /// log paginates incrementally without an explicit "fetch more"
+    /// gesture.
+    ///
+    /// Threshold: trigger when `scroll_offset` is within 50 lines of the
+    /// loaded top — i.e. the next handful of PageUps would otherwise hit
+    /// the boundary. Idempotent: `load_older_messages` already early-
+    /// returns when `history_exhausted` is set.
+    pub(crate) fn maybe_paginate_log_buffer(&mut self) {
+        let Some(active_id) = self.state.active_buffer_id.clone() else {
+            return;
+        };
+        let Some(buf) = self.state.buffers.get(&active_id) else {
+            return;
+        };
+        if buf.buffer_type != BufferType::Log || buf.history_exhausted {
+            return;
+        }
+        let messages_len = buf.messages.len();
+        if self.scroll_offset.saturating_add(50) >= messages_len {
+            self.load_older_messages(&active_id);
+        }
+    }
 }
 
 /// Convert a row read from `messages` into the in-memory `Message`

--- a/src/app/mentions.rs
+++ b/src/app/mentions.rs
@@ -34,6 +34,7 @@ impl App {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         };
         self.state
             .buffers

--- a/src/app/mentions.rs
+++ b/src/app/mentions.rs
@@ -30,6 +30,10 @@ impl App {
             list_modes: std::collections::HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         };
         self.state
             .buffers

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -454,8 +454,26 @@ impl App {
     /// Connection ID for the app-level default Status buffer.
     pub const DEFAULT_CONN_ID: &'static str = "_default";
 
-    #[allow(clippy::too_many_lines)]
     pub fn new() -> Result<Self> {
+        Self::new_with_mode(false)
+    }
+
+    /// Construct an `App` with chat-mode services optionally suppressed.
+    ///
+    /// `log_browser = true` skips the heavy IO that has no place in a
+    /// read-only history viewer:
+    /// * `Storage::init` (would open the DB write-mode, run retention
+    ///   purge, and spawn the LogWriter task — all wrong for a viewer).
+    /// * The RPE2E keyring init (depends on storage write access).
+    /// * The Lua scripting engine (no IRC events to react to).
+    ///
+    /// The remaining managers (DCC, Shell, web channels, image preview)
+    /// stay default-initialised — they have no side effects until used,
+    /// and keeping the field set non-`Option` keeps the struct readable.
+    /// `App::new_log_browser` then attaches a read-only `LogDb`
+    /// separately and rebuilds the sidebar from the message catalog.
+    #[allow(clippy::too_many_lines)]
+    pub fn new_with_mode(log_browser: bool) -> Result<Self> {
         constants::ensure_config_dir();
         let mut config = config::load_config(&constants::config_path())?;
 
@@ -476,7 +494,12 @@ impl App {
         state.nick_color_lit = config.display.nick_color_lightness;
         let (irc_tx, irc_rx) = mpsc::channel(4096);
 
-        let storage = if config.logging.enabled {
+        let storage = if log_browser {
+            // Log browser opens its own read-only handle later via
+            // `load_log_db` — skipping `Storage::init` here is the
+            // whole point of the read-only mode.
+            None
+        } else if config.logging.enabled {
             match crate::storage::Storage::init(&config.logging) {
                 Ok(s) => {
                     state.log_tx = Some(s.log_tx.clone());
@@ -583,13 +606,15 @@ impl App {
         );
         let mut script_manager =
             crate::scripting::engine::ScriptManager::new(constants::scripts_dir());
-        match crate::scripting::lua::LuaEngine::new() {
-            Ok(lua_engine) => {
-                script_manager.register_engine(Box::new(lua_engine));
-                tracing::info!("Lua scripting engine registered");
-            }
-            Err(e) => {
-                tracing::error!("failed to initialize Lua engine: {e}");
+        if !log_browser {
+            match crate::scripting::lua::LuaEngine::new() {
+                Ok(lua_engine) => {
+                    script_manager.register_engine(Box::new(lua_engine));
+                    tracing::info!("Lua scripting engine registered");
+                }
+                Err(e) => {
+                    tracing::error!("failed to initialize Lua engine: {e}");
+                }
             }
         }
 
@@ -871,6 +896,7 @@ impl App {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
         state.set_active_buffer(&buf_id);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -3,6 +3,7 @@ mod dcc;
 mod image;
 mod input;
 mod irc;
+mod log_browser;
 mod maintenance;
 mod mentions;
 mod scripting;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
-mod backlog;
+#[allow(clippy::redundant_pub_crate, reason = "log_browser reuses format_date_separator")]
+pub(crate) mod backlog;
 mod dcc;
 mod image;
 mod input;
@@ -409,7 +410,7 @@ pub struct App {
     /// autoconnect; sidebar source is rebuilt from the read-only `log_db`.
     pub log_browser_mode: bool,
     /// Present when `log_browser_mode == true`. Bundles the read-only
-    /// SQLite handle plus the optional crypto key used to decrypt rows
+    /// `SQLite` handle plus the optional crypto key used to decrypt rows
     /// when `[storage] encrypt = true`.
     pub log_db: Option<crate::storage::LogDb>,
     pub(crate) socket_listener: Option<tokio::net::UnixListener>,
@@ -463,7 +464,7 @@ impl App {
     /// `log_browser = true` skips the heavy IO that has no place in a
     /// read-only history viewer:
     /// * `Storage::init` (would open the DB write-mode, run retention
-    ///   purge, and spawn the LogWriter task — all wrong for a viewer).
+    ///   purge, and spawn the `LogWriter` task — all wrong for a viewer).
     /// * The RPE2E keyring init (depends on storage write access).
     /// * The Lua scripting engine (no IRC events to react to).
     ///

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -917,41 +917,53 @@ impl App {
             self.run_splash().await?;
         }
 
-        // In detached mode the shim has nothing to attach to without the
-        // session socket — fail loud so main()'s parent waitpid surfaces
-        // it instead of leaving a zombie-running headless backend that
-        // the user can never reach. In direct mode (terminal already
-        // owned by this process) the socket is a nice-to-have.
-        if let Err(e) = self.start_socket_listener() {
-            if self.detached {
-                return Err(e.wrap_err("failed to start session socket"));
+        // Log-browser mode owns the terminal directly, has no IRC at all,
+        // and intentionally has no shim — every chat-mode subsystem below
+        // is short-circuited by the `log_browser_mode` flag.
+        if !self.log_browser_mode {
+            // In detached mode the shim has nothing to attach to without the
+            // session socket — fail loud so main()'s parent waitpid surfaces
+            // it instead of leaving a zombie-running headless backend that
+            // the user can never reach. In direct mode (terminal already
+            // owned by this process) the socket is a nice-to-have.
+            if let Err(e) = self.start_socket_listener() {
+                if self.detached {
+                    return Err(e.wrap_err("failed to start session socket"));
+                }
+                tracing::warn!("session socket unavailable: {e}");
             }
-            tracing::warn!("session socket unavailable: {e}");
         }
 
-        let autoconnect_ids: Vec<String> = self
-            .config
-            .servers
-            .iter()
-            .filter(|(_, cfg)| cfg.autoconnect)
-            .map(|(id, _)| id.clone())
-            .collect();
+        let autoconnect_ids: Vec<String> = if self.log_browser_mode {
+            Vec::new()
+        } else {
+            self.config
+                .servers
+                .iter()
+                .filter(|(_, cfg)| cfg.autoconnect)
+                .map(|(id, _)| id.clone())
+                .collect()
+        };
 
-        if self.state.buffers.is_empty() {
+        if !self.log_browser_mode && self.state.buffers.is_empty() {
             Self::create_default_status(&mut self.state);
         }
 
-        self.autoload_scripts();
+        if !self.log_browser_mode {
+            self.autoload_scripts();
 
-        if self.config.display.mentions_buffer {
-            self.create_mentions_buffer();
+            if self.config.display.mentions_buffer {
+                self.create_mentions_buffer();
+            }
         }
 
         if self.terminal.is_some() && !self.is_socket_attached {
             self.start_term_reader();
         }
 
-        self.start_web_server().await;
+        if !self.log_browser_mode {
+            self.start_web_server().await;
+        }
 
         let mut pending_autoconnect_ids = (!autoconnect_ids.is_empty()).then_some(autoconnect_ids);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1148,6 +1148,16 @@ impl App {
                     if let Some(server_ids) = pending_autoconnect_ids.take() {
                         self.start_autoconnects(&server_ids);
                     }
+                    // Log mode lazy-loads the active buffer's history on
+                    // first activation. `load_initial_messages` is
+                    // idempotent (early-return if already loaded), so a
+                    // tick-time poll keeps the implementation trivial —
+                    // no extra signal plumbing needed.
+                    if self.log_browser_mode
+                        && let Some(active_id) = self.state.active_buffer_id.clone()
+                    {
+                        self.load_initial_messages(&active_id);
+                    }
                     self.handle_netsplit_tick();
                     self.purge_expired_batches();
                     self.check_reconnects();

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -403,6 +403,14 @@ pub struct App {
     pub terminal: Option<ui::Tui>,
     pub detached: bool,
     pub should_detach: bool,
+    /// `true` when the process was started via `repartee l`. Disables IRC
+    /// connections, the session socket listener, web server, scripts and
+    /// autoconnect; sidebar source is rebuilt from the read-only `log_db`.
+    pub log_browser_mode: bool,
+    /// Present when `log_browser_mode == true`. Bundles the read-only
+    /// SQLite handle plus the optional crypto key used to decrypt rows
+    /// when `[storage] encrypt = true`.
+    pub log_db: Option<crate::storage::LogDb>,
     pub(crate) socket_listener: Option<tokio::net::UnixListener>,
     pub(crate) socket_output_tx:
         Option<tokio::sync::mpsc::UnboundedSender<crate::session::protocol::MainMessage>>,
@@ -642,6 +650,8 @@ impl App {
             terminal: None,
             detached: false,
             should_detach: false,
+            log_browser_mode: false,
+            log_db: None,
             socket_listener: None,
             socket_output_tx: None,
             shim_event_rx: None,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -856,6 +856,10 @@ impl App {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
         state.set_active_buffer(&buf_id);
 

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -677,7 +677,7 @@ impl App {
             terminal: None,
             detached: false,
             should_detach: false,
-            log_browser_mode: false,
+            log_browser_mode: log_browser,
             log_db: None,
             socket_listener: None,
             socket_output_tx: None,

--- a/src/app/shell.rs
+++ b/src/app/shell.rs
@@ -134,6 +134,7 @@ impl App {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
     }
 

--- a/src/app/shell.rs
+++ b/src/app/shell.rs
@@ -130,6 +130,10 @@ impl App {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
     }
 

--- a/src/commands/handlers_irc.rs
+++ b/src/commands/handlers_irc.rs
@@ -874,6 +874,7 @@ fn ensure_query_buffer(app: &mut App, conn_id: &str, target: &str, skip_channels
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
     }
     buffer_id

--- a/src/commands/handlers_irc.rs
+++ b/src/commands/handlers_irc.rs
@@ -870,6 +870,10 @@ fn ensure_query_buffer(app: &mut App, conn_id: &str, target: &str, skip_channels
             list_modes: std::collections::HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
     }
     buffer_id

--- a/src/commands/handlers_logs.rs
+++ b/src/commands/handlers_logs.rs
@@ -29,6 +29,10 @@ pub(crate) fn cmd_log_help(app: &mut App, _args: &[String]) {
     add_local_event(app, "Hotkeys (outside input): Q quit, ↑/↓ scroll, PgUp/PgDn page, g/G start/end");
 }
 
+#[expect(
+    clippy::too_many_lines,
+    reason = "flat dispatch over plain/encrypted paths; splitting hurts readability"
+)]
 pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
     const SEARCH_LIMIT: usize = 1000;
     if args.is_empty() {
@@ -84,9 +88,10 @@ pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
         // Encrypted path: pull a bounded slice of recent rows
         // (decrypted by `get_messages`) and filter case-insensitively
         // in memory. The cap exists so a 100k-row encrypted log
-        // doesn't freeze the TUI on a single `/search` — better to
-        // tell the user we scanned the most recent N and offer
-        // narrowing the query than to block the runtime.
+        // doesn't freeze the TUI on a single `/search`. The header
+        // line below labels the result as "recent rows" when we hit
+        // the cap so the user knows older history was not searched —
+        // older-anchored search lands with `/jump` in V1.1.
         const MAX_ENCRYPTED_SCAN: usize = 10_000;
         let Ok(db) = log_db.db.lock() else {
             add_local_event(app, "Log DB lock poisoned");
@@ -109,25 +114,49 @@ pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
             }
         };
         drop(db);
-        let scan_capped = scanned.len() == MAX_ENCRYPTED_SCAN;
         let needle = query.to_lowercase();
+        let scan_capped = scanned.len() == MAX_ENCRYPTED_SCAN;
         let hits: Vec<_> = scanned
             .into_iter()
             .filter(|m| m.text.to_lowercase().contains(&needle))
             .take(SEARCH_LIMIT)
             .collect();
-        if scan_capped {
-            add_local_event(
-                app,
-                &format!(
-                    "[encrypted /search scanned the most recent {MAX_ENCRYPTED_SCAN} rows; \
-                     narrow the query or use /jump to anchor older]"
-                ),
-            );
+        // Header line tells the user up front whether this was a
+        // full-buffer search (FTS-impossible because encrypted, but
+        // we did go end-to-end of the active buffer) or a recent-only
+        // scan. Pkt 1 review nit: the previous wording made every
+        // result look like a full search.
+        let header = if scan_capped {
+            format!(
+                "[{} matches for \"{}\" in last {} rows of {}/{} \
+                 (encrypted; narrow the query to reach older)]",
+                hits.len(),
+                query,
+                MAX_ENCRYPTED_SCAN,
+                net,
+                buf,
+            )
+        } else {
+            format!(
+                "[{} matches for \"{}\" in {}/{}]",
+                hits.len(),
+                query,
+                net,
+                buf,
+            )
+        };
+        add_local_event(app, &header);
+        for hit in hits {
+            let when = chrono::DateTime::<chrono::Utc>::from_timestamp(hit.timestamp, 0)
+                .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+                .unwrap_or_default();
+            let nick = hit.nick.as_deref().unwrap_or("*");
+            add_local_event(app, &format!("{when}  <{nick}> {}", hit.text));
         }
-        hits
+        return;
     };
 
+    // Plain (FTS) path header.
     add_local_event(
         app,
         &format!("[{} matches for \"{}\" in {}/{}]", rows.len(), query, net, buf),

--- a/src/commands/handlers_logs.rs
+++ b/src/commands/handlers_logs.rs
@@ -8,6 +8,12 @@
 //!
 //! V1 surface: `/search`, `/quit`, `/help`. Future: `/jump`, `/grep`.
 
+#![allow(clippy::redundant_pub_crate)]
+#![allow(
+    clippy::missing_const_for_fn,
+    reason = "consistent with other command handlers"
+)]
+
 use crate::app::App;
 use crate::commands::helpers::add_local_event;
 

--- a/src/commands/handlers_logs.rs
+++ b/src/commands/handlers_logs.rs
@@ -30,6 +30,7 @@ pub(crate) fn cmd_log_help(app: &mut App, _args: &[String]) {
 }
 
 pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
+    const SEARCH_LIMIT: usize = 1000;
     if args.is_empty() {
         add_local_event(app, "Usage: /search <text>");
         return;
@@ -47,37 +48,78 @@ pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
         add_local_event(app, "Log DB unavailable");
         return;
     };
-    if !log_db.has_fts {
-        // search_messages requires FTS. With an encrypted DB we'd need a
-        // LIKE fallback; defer that to V1.1.
-        add_local_event(
-            app,
-            "/search requires plain-text logs; enable [storage] encrypt = false to use it",
-        );
-        return;
-    }
 
-    let hits = {
+    // FTS5 is gated on the schema being plain-text — encrypted logs
+    // store ciphertext, so the FTS index is never built. Two query
+    // paths:
+    //
+    //   plain DB     → `search_messages` (FTS5) — fast, ranks by
+    //                  match relevance, supports phrase queries.
+    //   encrypted DB → fetch the buffer through `get_messages` so
+    //                  rows are decrypted in-process, then filter
+    //                  in Rust with `text.contains(query)`. Slower
+    //                  (whole buffer scan) but correctness over
+    //                  performance — encrypted users still get
+    //                  /search instead of a useless error.
+    let rows = if log_db.has_fts {
         let Ok(db) = log_db.db.lock() else {
             add_local_event(app, "Log DB lock poisoned");
             return;
         };
-        crate::storage::query::search_messages(&db, &query, Some(&net), Some(&buf), 100)
-    };
-    match hits {
-        Ok(rows) => {
-            add_local_event(
-                app,
-                &format!("[{} matches for \"{}\" in {}/{}]", rows.len(), query, net, buf),
-            );
-            for hit in rows {
-                let when = chrono::DateTime::<chrono::Utc>::from_timestamp(hit.timestamp, 0)
-                    .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
-                    .unwrap_or_default();
-                let nick = hit.nick.as_deref().unwrap_or("*");
-                add_local_event(app, &format!("{when}  <{nick}> {}", hit.text));
+        match crate::storage::query::search_messages(
+            &db,
+            &query,
+            Some(&net),
+            Some(&buf),
+            SEARCH_LIMIT,
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                drop(db);
+                add_local_event(app, &format!("Search failed: {e}"));
+                return;
             }
         }
-        Err(e) => add_local_event(app, &format!("Search failed: {e}")),
+    } else {
+        // Encrypted path: pull every row in this buffer (decrypted by
+        // `get_messages`) then filter case-insensitively in memory.
+        let Ok(db) = log_db.db.lock() else {
+            add_local_event(app, "Log DB lock poisoned");
+            return;
+        };
+        let all = match crate::storage::query::get_messages(
+            &db,
+            &net,
+            &buf,
+            None,
+            usize::MAX,
+            true,
+            log_db.crypto_key.as_ref(),
+        ) {
+            Ok(r) => r,
+            Err(e) => {
+                drop(db);
+                add_local_event(app, &format!("Search failed: {e}"));
+                return;
+            }
+        };
+        drop(db);
+        let needle = query.to_lowercase();
+        all.into_iter()
+            .filter(|m| m.text.to_lowercase().contains(&needle))
+            .take(SEARCH_LIMIT)
+            .collect()
+    };
+
+    add_local_event(
+        app,
+        &format!("[{} matches for \"{}\" in {}/{}]", rows.len(), query, net, buf),
+    );
+    for hit in rows {
+        let when = chrono::DateTime::<chrono::Utc>::from_timestamp(hit.timestamp, 0)
+            .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+            .unwrap_or_default();
+        let nick = hit.nick.as_deref().unwrap_or("*");
+        add_local_event(app, &format!("{when}  <{nick}> {}", hit.text));
     }
 }

--- a/src/commands/handlers_logs.rs
+++ b/src/commands/handlers_logs.rs
@@ -1,0 +1,77 @@
+//! Slash command handlers active only when `app.log_browser_mode == true`.
+//!
+//! These are dispatched directly from `execute_command_with_depth` when the
+//! mode flag is set — they never reach `commands::registry`. Keeping them
+//! out of the global registry means the chat-mode help/list output stays
+//! free of log-only commands and the registry doesn't need a `condition`
+//! predicate.
+//!
+//! V1 surface: `/search`, `/quit`, `/help`. Future: `/jump`, `/grep`.
+
+use crate::app::App;
+use crate::commands::helpers::add_local_event;
+
+pub(crate) fn cmd_log_quit(app: &mut App, _args: &[String]) {
+    app.should_quit = true;
+}
+
+pub(crate) fn cmd_log_help(app: &mut App, _args: &[String]) {
+    add_local_event(app, "log mode commands:");
+    add_local_event(app, "  /search <text>   search the active log");
+    add_local_event(app, "  /quit            exit log browser");
+    add_local_event(app, "  /help            this list");
+    add_local_event(app, "Hotkeys (outside input): Q quit, ↑/↓ scroll, PgUp/PgDn page, g/G start/end");
+}
+
+pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
+    if args.is_empty() {
+        add_local_event(app, "Usage: /search <text>");
+        return;
+    }
+    let query = args.join(" ");
+    let Some(active_id) = app.state.active_buffer_id.clone() else {
+        add_local_event(app, "No active log buffer");
+        return;
+    };
+    let Some((net, buf)) = app.split_log_buffer_id(&active_id) else {
+        add_local_event(app, "Active buffer is not a log");
+        return;
+    };
+    let Some(log_db) = &app.log_db else {
+        add_local_event(app, "Log DB unavailable");
+        return;
+    };
+    if !log_db.has_fts {
+        // search_messages requires FTS. With an encrypted DB we'd need a
+        // LIKE fallback; defer that to V1.1.
+        add_local_event(
+            app,
+            "/search requires plain-text logs; enable [storage] encrypt = false to use it",
+        );
+        return;
+    }
+
+    let hits = {
+        let Ok(db) = log_db.db.lock() else {
+            add_local_event(app, "Log DB lock poisoned");
+            return;
+        };
+        crate::storage::query::search_messages(&db, &query, Some(&net), Some(&buf), 100)
+    };
+    match hits {
+        Ok(rows) => {
+            add_local_event(
+                app,
+                &format!("[{} matches for \"{}\" in {}/{}]", rows.len(), query, net, buf),
+            );
+            for hit in rows {
+                let when = chrono::DateTime::<chrono::Utc>::from_timestamp(hit.timestamp, 0)
+                    .map(|d| d.format("%Y-%m-%d %H:%M").to_string())
+                    .unwrap_or_default();
+                let nick = hit.nick.as_deref().unwrap_or("*");
+                add_local_event(app, &format!("{when}  <{nick}> {}", hit.text));
+            }
+        }
+        Err(e) => add_local_event(app, &format!("Search failed: {e}")),
+    }
+}

--- a/src/commands/handlers_logs.rs
+++ b/src/commands/handlers_logs.rs
@@ -81,18 +81,23 @@ pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
             }
         }
     } else {
-        // Encrypted path: pull every row in this buffer (decrypted by
-        // `get_messages`) then filter case-insensitively in memory.
+        // Encrypted path: pull a bounded slice of recent rows
+        // (decrypted by `get_messages`) and filter case-insensitively
+        // in memory. The cap exists so a 100k-row encrypted log
+        // doesn't freeze the TUI on a single `/search` — better to
+        // tell the user we scanned the most recent N and offer
+        // narrowing the query than to block the runtime.
+        const MAX_ENCRYPTED_SCAN: usize = 10_000;
         let Ok(db) = log_db.db.lock() else {
             add_local_event(app, "Log DB lock poisoned");
             return;
         };
-        let all = match crate::storage::query::get_messages(
+        let scanned = match crate::storage::query::get_messages(
             &db,
             &net,
             &buf,
             None,
-            usize::MAX,
+            MAX_ENCRYPTED_SCAN,
             true,
             log_db.crypto_key.as_ref(),
         ) {
@@ -104,11 +109,23 @@ pub(crate) fn cmd_log_search(app: &mut App, args: &[String]) {
             }
         };
         drop(db);
+        let scan_capped = scanned.len() == MAX_ENCRYPTED_SCAN;
         let needle = query.to_lowercase();
-        all.into_iter()
+        let hits: Vec<_> = scanned
+            .into_iter()
             .filter(|m| m.text.to_lowercase().contains(&needle))
             .take(SEARCH_LIMIT)
-            .collect()
+            .collect();
+        if scan_capped {
+            add_local_event(
+                app,
+                &format!(
+                    "[encrypted /search scanned the most recent {MAX_ENCRYPTED_SCAN} rows; \
+                     narrow the query or use /jump to anchor older]"
+                ),
+            );
+        }
+        hits
     };
 
     add_local_event(

--- a/src/commands/handlers_ui.rs
+++ b/src/commands/handlers_ui.rs
@@ -217,6 +217,11 @@ pub(crate) fn cmd_close(app: &mut App, args: &[String]) {
             // DCC chat buffers close like query buffers — just remove locally.
             app.state.remove_buffer(&buf_id);
         }
+        crate::state::buffer::BufferType::Log => {
+            // Log buffers are read-only — `/close` just removes them from the
+            // sidebar; the underlying SQLite rows are untouched.
+            app.state.remove_buffer(&buf_id);
+        }
         crate::state::buffer::BufferType::Shell => {
             // Shell close is handled by App::close_shell_buffer() — wired in Task 5.
             app.close_shell_buffer(&buf_id);

--- a/src/commands/handlers_ui.rs
+++ b/src/commands/handlers_ui.rs
@@ -714,6 +714,10 @@ fn shell_open(app: &mut App, command: Option<&str>) {
                 list_modes: HashMap::new(),
                 last_speakers: Vec::new(),
                 peer_handle: None,
+                log_total_lines: None,
+                log_oldest_ts: None,
+                log_newest_ts: None,
+                history_exhausted: false,
             });
             app.state.set_active_buffer(&buf_id);
             app.shell_input_active = true;

--- a/src/commands/handlers_ui.rs
+++ b/src/commands/handlers_ui.rs
@@ -718,6 +718,7 @@ fn shell_open(app: &mut App, command: Option<&str>) {
                 log_oldest_ts: None,
                 log_newest_ts: None,
                 history_exhausted: false,
+                log_initial_loaded: false,
             });
             app.state.set_active_buffer(&buf_id);
             app.shell_input_active = true;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -3,6 +3,7 @@ mod handlers_admin;
 pub(crate) mod handlers_dcc;
 mod handlers_e2e;
 mod handlers_irc;
+pub(crate) mod handlers_logs;
 mod handlers_ui;
 pub mod helpers;
 pub mod parser;

--- a/src/irc/batch.rs
+++ b/src/irc/batch.rs
@@ -529,6 +529,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Add users to the channel
@@ -763,6 +767,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Add users — add_nick stores keys as lowercase

--- a/src/irc/batch.rs
+++ b/src/irc/batch.rs
@@ -533,6 +533,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Add users to the channel
@@ -771,6 +772,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Add users — add_nick stores keys as lowercase

--- a/src/irc/events.rs
+++ b/src/irc/events.rs
@@ -832,6 +832,10 @@ fn handle_privmsg(
             } else {
                 Some(format!("{ident}@{host}"))
             },
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
     }
 
@@ -1293,6 +1297,10 @@ fn handle_join(
                 list_modes: std::collections::HashMap::new(),
                 last_speakers: Vec::new(),
                 peer_handle: None,
+                log_total_lines: None,
+                log_oldest_ts: None,
+                log_newest_ts: None,
+                history_exhausted: false,
             });
         }
         state.set_active_buffer(&buffer_id);
@@ -4162,6 +4170,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
         // Channel buffer
         let chan_id = make_buffer_id("test", "#test");
@@ -4182,6 +4194,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
         // Add ourselves to the channel
         state.add_nick(
@@ -4217,6 +4233,10 @@ mod tests {
             list_modes: std::collections::HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         }
     }
 
@@ -5065,6 +5085,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Add alice to both channels
@@ -5200,6 +5224,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Add alice to both channels
@@ -5328,6 +5356,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Add alice to both channels
@@ -5867,6 +5899,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         });
 
         // Server echoes our NOTICE to "bob"

--- a/src/irc/events.rs
+++ b/src/irc/events.rs
@@ -4107,6 +4107,10 @@ mod tests {
     use irc::proto::Prefix;
     use std::collections::HashMap;
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "flat fixture used by every test in this module"
+    )]
     fn make_test_state() -> AppState {
         let mut state = AppState::new();
         state.add_connection(Connection {

--- a/src/irc/events.rs
+++ b/src/irc/events.rs
@@ -836,6 +836,7 @@ fn handle_privmsg(
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
     }
 
@@ -1301,6 +1302,7 @@ fn handle_join(
                 log_oldest_ts: None,
                 log_newest_ts: None,
                 history_exhausted: false,
+                log_initial_loaded: false,
             });
         }
         state.set_active_buffer(&buffer_id);
@@ -4174,6 +4176,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
         // Channel buffer
         let chan_id = make_buffer_id("test", "#test");
@@ -4198,6 +4201,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
         // Add ourselves to the channel
         state.add_nick(
@@ -4237,6 +4241,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         }
     }
 
@@ -5089,6 +5094,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Add alice to both channels
@@ -5228,6 +5234,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Add alice to both channels
@@ -5360,6 +5367,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Add alice to both channels
@@ -5903,6 +5911,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         });
 
         // Server echoes our NOTICE to "bob"

--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,36 @@ fn main() -> Result<()> {
             .block_on(session::shim::run_shim(target_pid, false));
     }
 
+    // Handle log browser subcommand: `repartee l` or `repartee logs`.
+    // Direct mode like `attach` — no fork, no IRC, no socket listener.
+    // Pre-fork validation isn't needed here (we never fork) but config
+    // parse errors still surface inside `App::new` and reach the user's
+    // TTY directly.
+    if args.get(1).map(String::as_str) == Some("l")
+        || args.get(1).map(String::as_str) == Some("logs")
+    {
+        color_eyre::install()?;
+        setup_logging();
+        ui::install_panic_hook();
+        constants::ensure_config_dir();
+        return tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?
+            .block_on(async {
+                let mut app = app::App::new_log_browser()?;
+                if let Ok((cols, rows)) = crossterm::terminal::size() {
+                    app.cached_term_cols = cols;
+                    app.cached_term_rows = rows;
+                }
+                app.terminal = Some(ui::setup_terminal()?);
+                let result = app.run().await;
+                if let Some(ref mut terminal) = app.terminal {
+                    let _ = ui::restore_terminal(terminal);
+                }
+                result
+            });
+    }
+
     // Handle -d / --detach: start headless (no fork, no terminal).
     if args.iter().any(|a| a == "--detach" || a == "-d") {
         color_eyre::install()?;

--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -166,6 +166,17 @@ pub struct Buffer {
     /// refuses to send E2E traffic in that state rather than falling back
     /// to a nick-keyed row.
     pub peer_handle: Option<String>,
+    /// `BufferType::Log` only — total messages in the underlying SQLite
+    /// for this `(network, buffer)`, cached at activation so the topic-bar
+    /// render doesn't requery on every frame. `None` for non-log buffers.
+    pub log_total_lines: Option<u64>,
+    /// `BufferType::Log` only — oldest timestamp in the log range.
+    pub log_oldest_ts: Option<i64>,
+    /// `BufferType::Log` only — newest timestamp in the log range.
+    pub log_newest_ts: Option<i64>,
+    /// `BufferType::Log` only — set `true` once a paginated `load_older`
+    /// returns fewer rows than requested (we've hit the start of the log).
+    pub history_exhausted: bool,
 }
 
 impl Buffer {
@@ -212,6 +223,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         };
 
         buf.touch_speaker("alice");
@@ -243,6 +258,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         };
 
         buf.touch_speaker("Alice");
@@ -270,6 +289,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         };
 
         for i in 0..60 {

--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -17,6 +17,11 @@ pub enum BufferType {
     Special,
     /// Embedded PTY-backed shell terminal.
     Shell,
+    /// Read-only historical view of a logged channel/query opened by the
+    /// `repartee l` log browser. Same render path as `Channel`, but the
+    /// distinct variant lets predicates (e.g. `show_nicklist`) treat it
+    /// differently without extra plumbing.
+    Log,
 }
 
 impl BufferType {
@@ -24,7 +29,10 @@ impl BufferType {
         match self {
             Self::Mentions => 0,
             Self::Server => 1,
-            Self::Channel => 2,
+            // Log shares Channel's sort group: log buffers always sit under a
+            // pseudo-network whose connection_id starts with `_log_`, so they
+            // never mix with live channels in the sidebar.
+            Self::Channel | Self::Log => 2,
             Self::Query => 3,
             Self::DccChat => 4,
             Self::Special => 5,
@@ -292,5 +300,12 @@ mod tests {
         assert!(BufferType::Query.sort_group() < BufferType::DccChat.sort_group());
         assert!(BufferType::DccChat.sort_group() < BufferType::Special.sort_group());
         assert!(BufferType::Special.sort_group() < BufferType::Shell.sort_group());
+    }
+
+    #[test]
+    fn log_buffer_sorts_with_channels() {
+        // Log buffers live under pseudo-networks (different connection_id from
+        // any real channel), so the shared sort group is fine.
+        assert_eq!(BufferType::Log.sort_group(), BufferType::Channel.sort_group());
     }
 }

--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -177,6 +177,13 @@ pub struct Buffer {
     /// `BufferType::Log` only — set `true` once a paginated `load_older`
     /// returns fewer rows than requested (we've hit the start of the log).
     pub history_exhausted: bool,
+    /// `BufferType::Log` only — flips `true` after the first
+    /// `load_initial_messages` call returns from the database. We can't
+    /// gate on `messages.is_empty()` because slash-command errors and
+    /// the `/help` listing add `MessageType::Event` rows to the buffer
+    /// before the first lazy load fires; without an explicit flag the
+    /// real history would never load.
+    pub log_initial_loaded: bool,
 }
 
 impl Buffer {
@@ -227,6 +234,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         };
 
         buf.touch_speaker("alice");
@@ -262,6 +270,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         };
 
         buf.touch_speaker("Alice");
@@ -293,6 +302,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         };
 
         for i in 0..60 {

--- a/src/state/buffer.rs
+++ b/src/state/buffer.rs
@@ -166,7 +166,7 @@ pub struct Buffer {
     /// refuses to send E2E traffic in that state rather than falling back
     /// to a nick-keyed row.
     pub peer_handle: Option<String>,
-    /// `BufferType::Log` only — total messages in the underlying SQLite
+    /// `BufferType::Log` only — total messages in the underlying `SQLite`
     /// for this `(network, buffer)`, cached at activation so the topic-bar
     /// render doesn't requery on every frame. `None` for non-log buffers.
     pub log_total_lines: Option<u64>,

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -535,6 +535,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         }
     }
 

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -531,6 +531,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -122,6 +122,7 @@ impl AppState {
                     buffer::BufferType::DccChat => "dcc_chat",
                     buffer::BufferType::Special => "special",
                     buffer::BufferType::Shell => "shell",
+                    buffer::BufferType::Log => "log",
                 };
                 BufferInfo {
                     id: b.id.clone(),

--- a/src/state/sorting.rs
+++ b/src/state/sorting.rs
@@ -83,6 +83,10 @@ mod tests {
             list_modes: HashMap::new(),
             last_speakers: Vec::new(),
             peer_handle: None,
+            log_total_lines: None,
+            log_oldest_ts: None,
+            log_newest_ts: None,
+            history_exhausted: false,
         }
     }
 

--- a/src/state/sorting.rs
+++ b/src/state/sorting.rs
@@ -87,6 +87,7 @@ mod tests {
             log_oldest_ts: None,
             log_newest_ts: None,
             history_exhausted: false,
+            log_initial_loaded: false,
         }
     }
 

--- a/src/storage/crypto.rs
+++ b/src/storage/crypto.rs
@@ -255,6 +255,49 @@ mod tests {
     }
 
     #[test]
+    fn load_existing_key_errors_when_env_missing() {
+        // No .env file at the test path → must error, not auto-create.
+        let dir = std::env::temp_dir().join("repartee_loadexisting_no_env");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+        let err = load_existing_named_key_at(&path, "LOG_KEY").unwrap_err();
+        assert!(
+            err.contains("encrypted log requested"),
+            "should mention the missing key: {err}"
+        );
+        assert!(!path.exists(), "must not auto-create .env");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn load_existing_key_errors_when_key_line_missing() {
+        let dir = std::env::temp_dir().join("repartee_loadexisting_no_line");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+        std::fs::write(&path, "OTHER=value\n").unwrap();
+        let err = load_existing_named_key_at(&path, "LOG_KEY").unwrap_err();
+        assert!(
+            err.contains("not found in"),
+            "should mention the missing key line: {err}"
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn load_existing_key_returns_value_when_present() {
+        let dir = std::env::temp_dir().join("repartee_loadexisting_present");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(".env");
+        std::fs::write(&path, "REPARTEE_LOG_KEY=cafe1234\n").unwrap();
+        let key = load_existing_named_key_at(&path, "LOG_KEY").unwrap();
+        assert_eq!(key, "cafe1234");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
     fn load_or_create_key_roundtrip() {
         let dir = std::env::temp_dir().join(format!("repartee_test_{}", std::process::id()));
         std::fs::create_dir_all(&dir).unwrap();

--- a/src/storage/crypto.rs
+++ b/src/storage/crypto.rs
@@ -81,6 +81,43 @@ pub fn load_or_create_keyring_key() -> Result<String, String> {
     load_or_create_named_key_at(&path, "KEYRING_KEY")
 }
 
+/// Load the existing encryption key from the default `.env`. Errors
+/// (instead of silently generating a fresh key) when `LOG_KEY` is
+/// missing or empty. Used by the log browser, where creating a new key
+/// would produce a wrong cipher and an unreadable history.
+pub fn load_existing_key() -> Result<String, String> {
+    load_existing_named_key_at(&crate::constants::env_path(), "LOG_KEY")
+}
+
+fn load_existing_named_key_at(path: &Path, suffix: &str) -> Result<String, String> {
+    let key_name = env_key_name_with_suffix(suffix);
+    if !path.exists() {
+        return Err(format!(
+            "encrypted log requested but no {} found at {} \
+             (was the daemon ever started with [storage] encrypt = true?)",
+            key_name,
+            path.display()
+        ));
+    }
+    let file = std::fs::File::open(path)
+        .map_err(|e| format!("failed to open {}: {e}", path.display()))?;
+    let reader = std::io::BufReader::new(file);
+    for line in reader.lines() {
+        let line = line.map_err(|e| format!("failed to read line: {e}"))?;
+        if let Some(value) = line.trim().strip_prefix(&format!("{key_name}=")) {
+            let value = value.trim();
+            if !value.is_empty() {
+                return Ok(value.to_string());
+            }
+        }
+    }
+    Err(format!(
+        "{} not found in {} — cannot decrypt log without the key",
+        key_name,
+        path.display()
+    ))
+}
+
 /// Load the encryption key from `path`, or generate one and append it.
 ///
 /// The .env file is expected to contain lines like `KEY=value`.

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -222,17 +222,46 @@ pub fn open_database_at(path: &str, encrypt: bool) -> rusqlite::Result<Connectio
 /// Open the message database read-only.
 ///
 /// Used by the `repartee l` log browser. The `mode=ro` URI flag rejects
-/// all writes at the SQLite layer, so the daemon (running concurrently
+/// all writes at the `SQLite` layer, so the daemon (running concurrently
 /// against the same WAL) is never blocked. No pragmas are applied —
 /// `journal_mode=WAL` is a write operation and the file already carries
 /// the WAL setting from when the daemon created it. No schema creation:
 /// the database must already exist (we error out otherwise).
+///
+/// Path is percent-encoded for the URI form before being concatenated
+/// — a home directory like `/Users/Foo Bar/.repartee/...` would
+/// otherwise produce a malformed `file:` URI.
 pub fn open_readonly_at(path: &str) -> rusqlite::Result<Connection> {
-    let uri = format!("file:{path}?mode=ro");
+    let uri = format!("file:{}?mode=ro", encode_sqlite_uri_path(path));
     Connection::open_with_flags(
         &uri,
         rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
     )
+}
+
+/// Percent-encode characters that have special meaning inside a
+/// `SQLite` `file:` URI. Conservative encoder — only escapes the specific
+/// characters that break URI parsing (`?`, `#`, `%`, whitespace) and
+/// the byte range outside printable ASCII. `/` and `:` are preserved
+/// so `/tmp/x.db` stays readable. Per `SQLite` docs any character may
+/// be percent-encoded; we deliberately keep the encoded set narrow to
+/// keep error messages readable when the path appears in diagnostics.
+fn encode_sqlite_uri_path(path: &str) -> String {
+    let mut out = String::with_capacity(path.len());
+    for byte in path.as_bytes() {
+        match byte {
+            b'?' | b'#' | b'%' | b' ' | b'\t' | b'\n' | b'\r' => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "%{byte:02X}");
+            }
+            b if b.is_ascii() && !b.is_ascii_control() => out.push(*b as char),
+            b => {
+                use std::fmt::Write as _;
+                let _ = write!(out, "%{b:02X}");
+            }
+        }
+    }
+    out
 }
 
 pub fn purge_old_messages(db: &Connection, retention_days: u32, has_fts: bool) -> usize {
@@ -506,6 +535,46 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn encode_sqlite_uri_path_handles_special_chars() {
+        // Plain path: untouched.
+        assert_eq!(encode_sqlite_uri_path("/tmp/x.db"), "/tmp/x.db");
+        // Spaces: encoded so `?mode=ro` parses correctly.
+        assert_eq!(
+            encode_sqlite_uri_path("/Users/Foo Bar/.repartee/messages.db"),
+            "/Users/Foo%20Bar/.repartee/messages.db"
+        );
+        // Question mark, hash, percent: all encoded.
+        assert_eq!(encode_sqlite_uri_path("/a?b#c%d"), "/a%3Fb%23c%25d");
+    }
+
+    #[test]
+    fn open_readonly_handles_path_with_spaces() {
+        let dir = std::env::temp_dir().join("repartee logbrowser ro space");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("messages.db");
+        let path_str = path.to_str().unwrap();
+
+        // Seed via the writable opener.
+        let rw = open_database_at(path_str, false).unwrap();
+        rw.execute(
+            "INSERT INTO messages (timestamp, network, buffer, type, nick, text) \
+             VALUES (?1, 'libera', '#test', 'message', 'ada', 'hello')",
+            params![100],
+        )
+        .unwrap();
+        drop(rw);
+
+        let ro = open_readonly_at(path_str).unwrap();
+        let count: i64 = ro
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -219,6 +219,22 @@ pub fn open_database_at(path: &str, encrypt: bool) -> rusqlite::Result<Connectio
     Ok(db)
 }
 
+/// Open the message database read-only.
+///
+/// Used by the `repartee l` log browser. The `mode=ro` URI flag rejects
+/// all writes at the SQLite layer, so the daemon (running concurrently
+/// against the same WAL) is never blocked. No pragmas are applied —
+/// `journal_mode=WAL` is a write operation and the file already carries
+/// the WAL setting from when the daemon created it. No schema creation:
+/// the database must already exist (we error out otherwise).
+pub fn open_readonly_at(path: &str) -> rusqlite::Result<Connection> {
+    let uri = format!("file:{path}?mode=ro");
+    Connection::open_with_flags(
+        &uri,
+        rusqlite::OpenFlags::SQLITE_OPEN_READ_ONLY | rusqlite::OpenFlags::SQLITE_OPEN_URI,
+    )
+}
+
 pub fn purge_old_messages(db: &Connection, retention_days: u32, has_fts: bool) -> usize {
     let cutoff = chrono::Utc::now().timestamp() - i64::from(retention_days) * 86400;
 
@@ -490,5 +506,40 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM messages", [], |row| row.get(0))
             .unwrap();
         assert_eq!(count, 3);
+    }
+
+    #[test]
+    fn open_readonly_rejects_writes() {
+        // Need a real file (URI mode=ro doesn't apply to in-memory).
+        let dir = std::env::temp_dir().join("repartee_logbrowser_ro_test");
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("messages.db");
+        let path_str = path.to_str().unwrap();
+
+        // Seed via the writable opener.
+        let rw = open_database_at(path_str, false).unwrap();
+        rw.execute(
+            "INSERT INTO messages (timestamp, network, buffer, type, nick, text) \
+             VALUES (?1, 'libera', '#test', 'message', 'ada', 'hello')",
+            params![100],
+        )
+        .unwrap();
+        drop(rw);
+
+        let ro = open_readonly_at(path_str).unwrap();
+        let count: i64 = ro
+            .query_row("SELECT COUNT(*) FROM messages", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+
+        let write_err = ro.execute(
+            "INSERT INTO messages (timestamp, network, buffer, type, nick, text) \
+             VALUES (1, 'a', 'b', 'message', 'c', 'd')",
+            [],
+        );
+        assert!(write_err.is_err(), "read-only handle must reject writes");
+
+        std::fs::remove_dir_all(&dir).unwrap();
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -94,3 +94,47 @@ impl Storage {
         self.writer.shutdown().await;
     }
 }
+
+/// Read-only handle bundle used by the `repartee l` log browser. Same
+/// crypto-key derivation as `Storage::init`, but no writer task — we
+/// only ever read from this handle.
+#[allow(dead_code)]
+pub struct LogDb {
+    pub db: Arc<Mutex<Connection>>,
+    pub crypto_key: Option<aes_gcm::Key<aes_gcm::Aes256Gcm>>,
+    /// `false` when `[storage] encrypt = true` (FTS triggers can't index
+    /// ciphertext), `true` for plain logs. Drives the `/search` fallback
+    /// from FTS to `LIKE`.
+    pub has_fts: bool,
+}
+
+/// Open the message database read-only and (when `[storage] encrypt =
+/// true`) load the same AES-256-GCM key the daemon uses. Returns a
+/// human-readable error so `repartee l` can print it on the user's TTY
+/// directly.
+pub fn load_log_db(config: &LoggingConfig) -> Result<LogDb, String> {
+    let db_dir = constants::log_dir();
+    let db_path = db_dir.join("messages.db");
+    if !db_path.exists() {
+        return Err(format!(
+            "no message log at {} — start `repartee` and chat first",
+            db_path.display()
+        ));
+    }
+    let path_str = db_path.to_str().ok_or("invalid log dir path")?;
+    let conn = db::open_readonly_at(path_str)
+        .map_err(|e| format!("failed to open log database: {e}"))?;
+
+    let crypto_key = if config.encrypt {
+        let hex_key = crypto::load_or_create_key()?;
+        Some(crypto::import_key(&hex_key)?)
+    } else {
+        None
+    };
+
+    Ok(LogDb {
+        db: Arc::new(Mutex::new(conn)),
+        crypto_key,
+        has_fts: !config.encrypt,
+    })
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -125,8 +125,13 @@ pub fn load_log_db(config: &LoggingConfig) -> Result<LogDb, String> {
     let conn = db::open_readonly_at(path_str)
         .map_err(|e| format!("failed to open log database: {e}"))?;
 
+    // Important: `load_existing_key`, NOT `load_or_create_key`. If the
+    // user's LOG_KEY went missing for any reason (deleted .env, copied
+    // DB onto a fresh machine), generating a fresh key would produce a
+    // bad cipher and a silent empty UI. We surface a clear error
+    // instead.
     let crypto_key = if config.encrypt {
-        let hex_key = crypto::load_or_create_key()?;
+        let hex_key = crypto::load_existing_key()?;
         Some(crypto::import_key(&hex_key)?)
     } else {
         None

--- a/src/storage/query.rs
+++ b/src/storage/query.rs
@@ -107,6 +107,64 @@ pub fn get_messages(
     Ok(messages)
 }
 
+/// Cursor-paginated fetch using a `(timestamp, id)` tuple as the cursor.
+///
+/// `get_messages` alone uses `WHERE timestamp < ?` which silently drops
+/// rows that share a timestamp with the cursor — a real problem when
+/// many messages land in the same second on a busy channel. This
+/// variant uses the strict ordering `(timestamp DESC, id DESC)` and
+/// `WHERE timestamp < ?ts OR (timestamp = ?ts AND id < ?id)`, so paging
+/// is lossless even at second-precision timestamps.
+///
+/// Pass `before = None` for the initial page (latest messages). Used by
+/// the log browser; chat-mode `load_backlog` keeps using the simpler
+/// timestamp-only `get_messages` because backlog is one-shot, not
+/// paginated.
+pub fn get_messages_paginated(
+    db: &Connection,
+    network: &str,
+    buffer: &str,
+    before: Option<(i64, i64)>,
+    limit: usize,
+    encrypt: bool,
+    crypto_key: Option<&Key<Aes256Gcm>>,
+) -> rusqlite::Result<Vec<StoredMessage>> {
+    let mut messages = if let Some((ts, id)) = before {
+        let mut stmt = db.prepare(
+            "SELECT * FROM messages
+             WHERE network = ?1 AND buffer = ?2
+               AND (timestamp < ?3 OR (timestamp = ?3 AND id < ?4))
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?5",
+        )?;
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "limit will never exceed i64::MAX in practice"
+        )]
+        let rows = stmt.query_map(params![network, buffer, ts, id, limit as i64], |row| {
+            map_row(row, encrypt, crypto_key)
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    } else {
+        let mut stmt = db.prepare(
+            "SELECT * FROM messages
+             WHERE network = ?1 AND buffer = ?2
+             ORDER BY timestamp DESC, id DESC
+             LIMIT ?3",
+        )?;
+        #[expect(
+            clippy::cast_possible_wrap,
+            reason = "limit will never exceed i64::MAX in practice"
+        )]
+        let rows = stmt.query_map(params![network, buffer, limit as i64], |row| {
+            map_row(row, encrypt, crypto_key)
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    messages.reverse();
+    Ok(messages)
+}
+
 /// Full-text search across messages (plain mode only, no encryption).
 ///
 /// The query string is wrapped in double quotes for phrase matching.
@@ -724,6 +782,47 @@ mod tests {
             vec!["#debian"]
         );
         assert!(list_buffers_for_network(&db, "missing").unwrap().is_empty());
+    }
+
+    #[test]
+    fn get_messages_paginated_does_not_lose_same_timestamp_rows() {
+        // Regression: timestamp-only pagination drops rows when many
+        // messages share the same second. Composite (timestamp, id)
+        // cursor pages through them losslessly.
+        let db = setup_test_db();
+        // Insert 5 rows with the same timestamp but distinct msg_ids
+        // (UNIQUE constraint), distinct text so we can verify identity.
+        for i in 0..5 {
+            db.execute(
+                "INSERT INTO messages (msg_id, network, buffer, timestamp, type, nick, text, highlight) \
+                 VALUES (?1, 'libera', '#rust', 100, 'message', 'ada', ?2, 0)",
+                params![format!("dup-{i}"), format!("text-{i}")],
+            )
+            .unwrap();
+        }
+        // Sanity: 5 rows at ts=100, distinct ids assigned by SQLite.
+        let all =
+            get_messages_paginated(&db, "libera", "#rust", None, 1000, false, None).unwrap();
+        assert_eq!(all.len(), 5);
+
+        // Page 1: limit 2 → 2 newest at ts=100.
+        let page1 =
+            get_messages_paginated(&db, "libera", "#rust", None, 2, false, None).unwrap();
+        assert_eq!(page1.len(), 2);
+        let oldest = page1.first().unwrap();
+        // Page 2: cursor on (ts=100, id=oldest.id) → must yield the
+        // remaining 3 rows that share timestamp 100, *not* return empty.
+        let page2 = get_messages_paginated(
+            &db,
+            "libera",
+            "#rust",
+            Some((oldest.timestamp, oldest.id)),
+            10,
+            false,
+            None,
+        )
+        .unwrap();
+        assert_eq!(page2.len(), 3, "all same-timestamp rows must paginate");
     }
 
     #[test]

--- a/src/storage/query.rs
+++ b/src/storage/query.rs
@@ -377,6 +377,59 @@ pub fn truncate_mentions(db: &Connection) -> rusqlite::Result<usize> {
     db.execute("DELETE FROM mentions", [])
 }
 
+// === Log-browser catalog queries ===
+
+/// Distinct networks present in the message log, sorted ascending.
+/// Used by the log browser to populate sidebar headers.
+pub fn list_networks(db: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = db.prepare("SELECT DISTINCT network FROM messages ORDER BY network")?;
+    let rows = stmt.query_map([], |r| r.get::<_, String>(0))?;
+    rows.collect()
+}
+
+/// Distinct buffers logged for a given network, sorted ascending.
+pub fn list_buffers_for_network(
+    db: &Connection,
+    network: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = db.prepare(
+        "SELECT DISTINCT buffer FROM messages WHERE network = ?1 ORDER BY buffer",
+    )?;
+    let rows = stmt.query_map(params![network], |r| r.get::<_, String>(0))?;
+    rows.collect()
+}
+
+/// `(line_count, oldest_ts, newest_ts)` for a given network/buffer pair.
+/// Returns `None` if no messages exist there. Cached on the `Buffer` at
+/// activation so the topic-bar render doesn't requery on every frame.
+pub fn buffer_stats(
+    db: &Connection,
+    network: &str,
+    buffer: &str,
+) -> rusqlite::Result<Option<(u64, i64, i64)>> {
+    let row = db.query_row(
+        "SELECT COUNT(*), MIN(timestamp), MAX(timestamp) \
+         FROM messages WHERE network = ?1 AND buffer = ?2",
+        params![network, buffer],
+        |r| {
+            let count: i64 = r.get(0)?;
+            // MIN/MAX are NULL when the count is 0.
+            let oldest: Option<i64> = r.get(1)?;
+            let newest: Option<i64> = r.get(2)?;
+            #[expect(
+                clippy::cast_sign_loss,
+                reason = "COUNT(*) is non-negative by SQL semantics"
+            )]
+            Ok((count as u64, oldest, newest))
+        },
+    )?;
+    Ok(match row {
+        (0, _, _) => None,
+        (n, Some(o), Some(x)) => Some((n, o, x)),
+        _ => None,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -638,5 +691,51 @@ mod tests {
         truncate_mentions(&db).unwrap();
         let remaining = load_recent_mentions(&db, 0, 1000).unwrap();
         assert!(remaining.is_empty());
+    }
+
+    // === Log-browser catalog queries ===
+
+    #[test]
+    fn list_networks_returns_distinct_sorted() {
+        let db = setup_test_db();
+        insert_msg(&db, "libera", "#rust", 1, "a");
+        insert_msg(&db, "libera", "#polska", 2, "b");
+        insert_msg(&db, "oftc", "#debian", 3, "c");
+        insert_msg(&db, "libera", "#rust", 4, "d");
+        insert_msg(&db, "ircnet", "#pl", 5, "e");
+
+        assert_eq!(list_networks(&db).unwrap(), vec!["ircnet", "libera", "oftc"]);
+    }
+
+    #[test]
+    fn list_buffers_for_network_filters_correctly() {
+        let db = setup_test_db();
+        insert_msg(&db, "libera", "#rust", 1, "x");
+        insert_msg(&db, "libera", "#polska", 2, "x");
+        insert_msg(&db, "oftc", "#debian", 3, "x");
+        insert_msg(&db, "libera", "#rust", 4, "y");
+
+        assert_eq!(
+            list_buffers_for_network(&db, "libera").unwrap(),
+            vec!["#polska", "#rust"]
+        );
+        assert_eq!(
+            list_buffers_for_network(&db, "oftc").unwrap(),
+            vec!["#debian"]
+        );
+        assert!(list_buffers_for_network(&db, "missing").unwrap().is_empty());
+    }
+
+    #[test]
+    fn buffer_stats_returns_count_and_range() {
+        let db = setup_test_db();
+        insert_msg(&db, "libera", "#rust", 100, "x");
+        insert_msg(&db, "libera", "#rust", 200, "y");
+        insert_msg(&db, "libera", "#rust", 50, "z");
+        insert_msg(&db, "libera", "#other", 9999, "q");
+
+        let stats = buffer_stats(&db, "libera", "#rust").unwrap();
+        assert_eq!(stats, Some((3, 50, 200)));
+        assert_eq!(buffer_stats(&db, "libera", "#unknown").unwrap(), None);
     }
 }

--- a/src/ui/status_line.rs
+++ b/src/ui/status_line.rs
@@ -205,24 +205,22 @@ fn render_log_status(
     fg_muted: Color,
     accent: Color,
 ) {
-    let active = app.state.active_buffer();
-    let (id_text, loaded, total, from) = match active {
-        Some(buf) => {
+    let (id_text, loaded, total, from) = app.state.active_buffer().map_or_else(
+        || (String::from("(no buffer)"), 0, 0, String::from("(empty)")),
+        |buf| {
             let id = buf
                 .connection_id
                 .strip_prefix(crate::app::App::LOG_CONN_PREFIX)
                 .map_or_else(|| buf.id.clone(), |net| format!("{net}/{}", buf.name));
             let total = buf.log_total_lines.unwrap_or(0);
             let loaded = buf.messages.len();
-            let from = buf
-                .messages
-                .front()
-                .map(|m| m.timestamp.format("%Y-%m-%d %H:%M").to_string())
-                .unwrap_or_else(|| String::from("(empty)"));
+            let from = buf.messages.front().map_or_else(
+                || String::from("(empty)"),
+                |m| m.timestamp.format("%Y-%m-%d %H:%M").to_string(),
+            );
             (id, loaded, total, from)
-        }
-        None => (String::from("(no buffer)"), 0, 0, String::from("(empty)")),
-    };
+        },
+    );
     let sep = Span::styled("  \u{2022}  ", Style::default().fg(fg_muted));
     let line = Line::from(vec![
         Span::styled("log mode", Style::default().fg(accent).add_modifier(Modifier::BOLD)),

--- a/src/ui/status_line.rs
+++ b/src/ui/status_line.rs
@@ -21,6 +21,11 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let fg_dim = hex_to_color(&colors.fg_dim).unwrap_or(Color::DarkGray);
     let accent = hex_to_color(&colors.accent).unwrap_or(Color::Cyan);
 
+    if app.log_browser_mode {
+        render_log_status(frame, area, app, fg, fg_muted, accent);
+        return;
+    }
+
     let separator = &app.config.statusbar.separator;
 
     // Get active buffer's connection
@@ -188,4 +193,53 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let line = Line::from(spans);
     let paragraph = Paragraph::new(line);
     frame.render_widget(paragraph, area);
+}
+
+/// Status line in log-browser mode. Layout:
+/// `log mode • <net>/<buf> • showing X/Y from <ts>  •  ↑/↓ scroll • / search • Q quit`
+fn render_log_status(
+    frame: &mut Frame,
+    area: Rect,
+    app: &App,
+    fg: Color,
+    fg_muted: Color,
+    accent: Color,
+) {
+    let active = app.state.active_buffer();
+    let (id_text, loaded, total, from) = match active {
+        Some(buf) => {
+            let id = buf
+                .connection_id
+                .strip_prefix(crate::app::App::LOG_CONN_PREFIX)
+                .map_or_else(|| buf.id.clone(), |net| format!("{net}/{}", buf.name));
+            let total = buf.log_total_lines.unwrap_or(0);
+            let loaded = buf.messages.len();
+            let from = buf
+                .messages
+                .front()
+                .map(|m| m.timestamp.format("%Y-%m-%d %H:%M").to_string())
+                .unwrap_or_else(|| String::from("(empty)"));
+            (id, loaded, total, from)
+        }
+        None => (String::from("(no buffer)"), 0, 0, String::from("(empty)")),
+    };
+    let sep = Span::styled("  \u{2022}  ", Style::default().fg(fg_muted));
+    let line = Line::from(vec![
+        Span::styled("log mode", Style::default().fg(accent).add_modifier(Modifier::BOLD)),
+        sep.clone(),
+        Span::styled(id_text, Style::default().fg(accent)),
+        sep.clone(),
+        Span::styled(
+            format!("showing {loaded}/{total}"),
+            Style::default().fg(fg),
+        ),
+        Span::styled(" from ", Style::default().fg(fg_muted)),
+        Span::styled(from, Style::default().fg(fg)),
+        sep,
+        Span::styled(
+            "↑/↓ scroll • / search • Q quit",
+            Style::default().fg(fg_muted),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
 }

--- a/src/ui/status_line.rs
+++ b/src/ui/status_line.rs
@@ -213,11 +213,26 @@ fn render_log_status(
                 .strip_prefix(crate::app::App::LOG_CONN_PREFIX)
                 .map_or_else(|| buf.id.clone(), |net| format!("{net}/{}", buf.name));
             let total = buf.log_total_lines.unwrap_or(0);
-            let loaded = buf.messages.len();
-            let from = buf.messages.front().map_or_else(
-                || String::from("(empty)"),
-                |m| m.timestamp.format("%Y-%m-%d %H:%M").to_string(),
-            );
+            // Count real DB rows only — `log_msg_id.is_some()` excludes
+            // synthetic day separators and the local-event lines that
+            // `/help`, `/search` results, and the slash-only hint emit.
+            let loaded = buf
+                .messages
+                .iter()
+                .filter(|m| m.log_msg_id.is_some())
+                .count();
+            // `from` is the timestamp of the oldest real message we've
+            // loaded — that's what the user actually wants to see ("how
+            // far back am I?"), not the timestamp of a synthetic
+            // separator that happens to share the same date.
+            let from = buf
+                .messages
+                .iter()
+                .find(|m| m.log_msg_id.is_some())
+                .map_or_else(
+                    || String::from("(empty)"),
+                    |m| m.timestamp.format("%Y-%m-%d %H:%M").to_string(),
+                );
             (id, loaded, total, from)
         },
     );

--- a/src/ui/topic_bar.rs
+++ b/src/ui/topic_bar.rs
@@ -2,6 +2,7 @@ use ratatui::prelude::*;
 use ratatui::widgets::Paragraph;
 
 use crate::app::App;
+use crate::state::buffer::{Buffer, BufferType};
 use crate::theme::hex_to_color;
 use crate::ui::styled_text::styled_spans_to_line_with_fg;
 
@@ -15,6 +16,9 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
     let topic_text = app.state.active_buffer().map_or_else(
         || Line::from(""),
         |buf| {
+            if buf.buffer_type == BufferType::Log {
+                return render_log_topic(buf, accent, fg, fg_muted);
+            }
             let channel = Span::styled(
                 buf.name.clone(),
                 Style::default().fg(accent).add_modifier(Modifier::BOLD),
@@ -35,4 +39,37 @@ pub fn render(frame: &mut Frame, area: Rect, app: &App) {
 
     let widget = Paragraph::new(topic_text).style(Style::default().bg(bg_alt));
     frame.render_widget(widget, area);
+}
+
+/// Topic-bar content for `BufferType::Log` buffers — shows the network/
+/// channel pair, the cached line count and the date range. Computed
+/// from the metadata cached on `Buffer` at activation, never queries
+/// the database.
+fn render_log_topic(buf: &Buffer, accent: Color, fg: Color, fg_muted: Color) -> Line<'static> {
+    let net = buf
+        .connection_id
+        .strip_prefix(App::LOG_CONN_PREFIX)
+        .unwrap_or(&buf.connection_id);
+    let total = buf.log_total_lines.unwrap_or(0);
+    let range = match (buf.log_oldest_ts, buf.log_newest_ts) {
+        (Some(o), Some(n)) => format!("{} → {}", format_log_date(o), format_log_date(n)),
+        _ => String::from("(empty)"),
+    };
+    let header = Span::styled(
+        format!("\u{1F4DC} Log: {} @ {}", buf.name, net),
+        Style::default().fg(accent).add_modifier(Modifier::BOLD),
+    );
+    let sep = Span::styled("  \u{2022}  ", Style::default().fg(fg_muted));
+    let lines = Span::styled(
+        format!("{total} lines"),
+        Style::default().fg(fg),
+    );
+    let range_span = Span::styled(range, Style::default().fg(fg));
+    Line::from(vec![header, sep.clone(), lines, sep, range_span])
+}
+
+fn format_log_date(ts: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(ts, 0)
+        .map(|dt| dt.format("%Y-%m-%d").to_string())
+        .unwrap_or_default()
 }

--- a/src/web/snapshot.rs
+++ b/src/web/snapshot.rs
@@ -149,6 +149,10 @@ mod tests {
                 list_modes: HashMap::new(),
                 last_speakers: Vec::new(),
                 peer_handle: None,
+                log_total_lines: None,
+                log_oldest_ts: None,
+                log_newest_ts: None,
+                history_exhausted: false,
             },
         );
         state

--- a/src/web/snapshot.rs
+++ b/src/web/snapshot.rs
@@ -112,6 +112,7 @@ pub const fn buffer_type_str(bt: &BufferType) -> &'static str {
         BufferType::DccChat => "dcc_chat",
         BufferType::Special => "special",
         BufferType::Shell => "shell",
+        BufferType::Log => "log",
     }
 }
 

--- a/src/web/snapshot.rs
+++ b/src/web/snapshot.rs
@@ -153,6 +153,7 @@ mod tests {
                 log_oldest_ts: None,
                 log_newest_ts: None,
                 history_exhausted: false,
+                log_initial_loaded: false,
             },
         );
         state


### PR DESCRIPTION
## Summary

Adds `repartee l` (alias `repartee logs`) — a standalone TUI log browser
that opens the existing SQLite history read-only and presents it through
the existing layout: topic bar, sidebar, scrollback, status line, input.

* **Pseudo-network sidebar** built from `SELECT DISTINCT (network, buffer)
  FROM messages` — every network gets a synthetic `Connection`, every
  channel/query a `BufferType::Log`. Friendly labels reused from the
  user's `[servers]` config when present.
* **Lazy load** via the existing `query::get_messages` cursor API: 200
  messages on activation, 200 more whenever `scroll_offset` is within 50
  lines of the top. `history_exhausted` flag flips when a paginated
  fetch returns short — further scrolls become no-ops.
* **Slash commands** restricted to `/search` (FTS5), `/quit`, `/help` —
  plain text and unknown verbs print a hint, never reach the IRC layer.
  `Q` outside the input also quits.
* **Topic bar / status line** branch on log mode to show metadata cached
  on the buffer (line count, date range, current scroll position) — no
  per-frame DB queries.
* **Architecture**: single `App.log_browser_mode: bool` flag short-
  circuits IRC connections, socket listener, web server, scripts,
  autoconnect. SQLite opened with `?mode=ro` URI so the daemon can keep
  writing through WAL while the browser reads.

V1.1 follow-ups: `/jump <date>`, `/grep <regex>`, optional right-side
"top authors" panel, web-UI mirror.

## Reference docs

* Design spec: `docs/superpowers/specs/2026-05-09-log-browser-design.md`
* Implementation plan: `docs/superpowers/plans/2026-05-09-log-browser.md`

## Test plan

* [x] \`cargo test -p repartee\` — 1072 passed (4 new: catalog queries +
  read-only open). 0 failures.
* [x] \`cargo clippy --tests --no-deps\` — no new warnings on touched
  files (pedantic + nursery + perf=deny + redundant_clone=deny).
* [x] \`cargo build --release\` — clean release build (~1m25s).
* [x] Smoke: \`repartee l\` against a seeded DB starts, sidebar renders
  pseudo-networks, \`/quit\` / \`Q\` exits cleanly. Verified up to the
  TTY-setup boundary in non-interactive shell — full interactive test
  requires a real terminal.
* [ ] Manual interactive test on the maintainer's terminal: open
  \`repartee l\` against the live `~/.repartee/logs/messages.db`,
  navigate buffers with Alt-↑/↓, page back through history with PgUp,
  run \`/search\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `repartee l` subcommand to launch a read-only TUI log browser
> - Adds a new `repartee l`/`repartee logs` CLI entry point in [main.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fc) that starts the app in log-browser mode without forking or connecting to IRC.
> - Introduces `App::new_log_browser()` and `App::new_with_mode(log_browser: bool)` in [src/app/mod.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-b2db4128ee8d3fd19ff317f148c1b2d9e8e6fe7bcd711ca80b5617c21dd5b97c); log-browser mode skips storage init, Lua scripting, the session socket, web server, autoconnects, and the mentions buffer.
> - Adds a new `BufferType::Log` variant in [src/state/buffer.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-0ba96d70ce87dae60dea3cce28ff2e046d8a6d38d5299d3a256eb9aa9905c9e8) and a `log_browser` module in [src/app/log_browser.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-97a1ed8e93066c3f4707aac44d927e3b0c578e9c5f50a58bb547e138dfc01db3) that builds a sidebar catalog from the log DB, lazily loads up to 200 messages per buffer, and paginates older history on scroll.
> - Restricts commands in log-browser mode to `/search`, `/quit`/`/exit`, and `/help` (see [src/commands/handlers_logs.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-41f89b266e5fc9f7cff3a6040b0a20338ed2bc6f501647b9ce7f9a90ce3d1718)); `/search` supports FTS5 for plain logs and in-memory decryption scan for encrypted logs.
> - Replaces the topic bar and status bar with log-specific renderers showing network/channel, total line count, date range, and loaded vs. total message counts when a `Log` buffer is active.
> - Adds read-only SQLite helpers (`db::open_readonly_at`, `storage::load_log_db`, `crypto::load_existing_key`) and cursor-paginated queries in [src/storage/query.rs](https://github.com/outragedevs/repartee/pull/3/files#diff-5e646cf48696ff8c35955aab60ab7ea0d836df3c9261d93a1610ad4cee25dea2) that avoid gaps when multiple rows share the same timestamp.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 08d7de4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->