### PR TITLE
fix(web): SSRF guard on /api/preview + review follow-ups

### DIFF
--- a/docs/src/content/web-frontend.md
+++ b/docs/src/content/web-frontend.md
@@ -41,12 +41,16 @@ All web settings live under the `[web]` section in `config.toml` and can be chan
 | `web.tls_cert` | *(auto)* | Path to TLS certificate (PEM). Empty = self-signed |
 | `web.tls_key` | *(auto)* | Path to TLS private key (PEM). Empty = self-signed |
 | `web.password` | *(from .env)* | Login password (set via `WEB_PASSWORD` in `.env`) |
-| `web.session_hours` | `24` | Session duration before re-login required |
+| `web.username` | `repartee` | Username pre-filled in the login form (only password is validated; the field exists so password managers recognise the form) |
+| `web.session_days` | `90` | Session lifetime in days. Sessions persist to `~/.repartee/web_sessions.bin` and survive process restart. |
 | `web.theme` | `nightfall` | Default theme (`nightfall`, `catppuccin-mocha`, `tokyo-storm`, `gruvbox-light`, `catppuccin-latte`) |
 | `web.timestamp_format` | `%H:%M` | Timestamp format (chrono strftime syntax) |
 | `web.line_height` | `1.35` | CSS line-height for chat messages |
 | `web.nick_column_width` | `12` | Nick column width in characters |
 | `web.nick_max_length` | `9` | Max nick display length before truncation |
+| `web.image_previews` | `false` | Show thumbnails under chat messages that contain image URLs. Server fetches + thumbnails on `/api/preview`; `i.imgur.com` direct images load client-side. |
+| `web.image_previews_max_per_msg` | `4` | Cap on previews shown per message |
+| `web.thumbnail_cache_mb` | `200` | Maximum size of the thumbnail cache on disk |
 
 Nick coloring settings live under `[display]` but are also synced to web clients:
 

--- a/docs/web-frontend.html
+++ b/docs/web-frontend.html
@@ -158,9 +158,14 @@ port = 8443
 <td>Login password (set via <code>WEB_PASSWORD</code> in <code>.env</code>)</td>
 </tr>
 <tr>
-<td><code>web.session_hours</code></td>
-<td><code>24</code></td>
-<td>Session duration before re-login required</td>
+<td><code>web.username</code></td>
+<td><code>repartee</code></td>
+<td>Username pre-filled in the login form (only password is validated; the field exists so password managers recognise the form)</td>
+</tr>
+<tr>
+<td><code>web.session_days</code></td>
+<td><code>90</code></td>
+<td>Session lifetime in days. Sessions persist to <code>~/.repartee/web_sessions.bin</code> and survive process restart.</td>
 </tr>
 <tr>
 <td><code>web.theme</code></td>
@@ -186,6 +191,21 @@ port = 8443
 <td><code>web.nick_max_length</code></td>
 <td><code>9</code></td>
 <td>Max nick display length before truncation</td>
+</tr>
+<tr>
+<td><code>web.image_previews</code></td>
+<td><code>false</code></td>
+<td>Show thumbnails under chat messages that contain image URLs. Server fetches + thumbnails on <code>/api/preview</code>; <code>i.imgur.com</code> direct images load client-side.</td>
+</tr>
+<tr>
+<td><code>web.image_previews_max_per_msg</code></td>
+<td><code>4</code></td>
+<td>Cap on previews shown per message</td>
+</tr>
+<tr>
+<td><code>web.thumbnail_cache_mb</code></td>
+<td><code>200</code></td>
+<td>Maximum size of the thumbnail cache on disk</td>
 </tr>
 </tbody></table>
 <p>Nick coloring settings live under <code>[display]</code> but are also synced to web clients:</p>

--- a/src/web/preview.rs
+++ b/src/web/preview.rs
@@ -23,6 +23,7 @@
 
 use std::collections::HashMap;
 use std::io::Cursor;
+use std::net::{IpAddr, SocketAddr, ToSocketAddrs};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -34,6 +35,7 @@ use axum_extra::extract::cookie::CookieJar;
 use image::ImageReader;
 use image::codecs::jpeg::JpegEncoder;
 use image::imageops::FilterType;
+use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use serde::{Deserialize, Serialize};
 
 use crate::image_preview::detect::{UrlClassification, UrlType, extract_urls};
@@ -102,8 +104,17 @@ impl WebPreviewExtractor {
     #[must_use]
     pub fn new(secret: Vec<u8>, max_per_msg: usize, cache_max_mb: u32) -> Self {
         let cache_dir = crate::constants::home_dir().join("web_thumbnails");
+        // SSRF guard: a public IRC URL must not let the server hit
+        // localhost / LAN / link-local / cloud metadata. We plug a custom
+        // resolver into reqwest that drops every non-public address
+        // returned by DNS, and we cap redirects so a malicious site can't
+        // stack rebinds. `PublicOnlyResolver` is invoked for every host —
+        // initial URL *and* each redirect — so the guard travels with the
+        // request.
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .dns_resolver(Arc::new(PublicOnlyResolver))
             .build()
             .unwrap_or_else(|_| reqwest::Client::new());
         Self {
@@ -228,6 +239,16 @@ pub async fn preview_handler(
     let Some(url) = extractor.lookup(&q.h) else {
         return StatusCode::NOT_FOUND.into_response();
     };
+
+    // 3a. SSRF pre-check on the original URL. The DNS resolver inside
+    //     reqwest already filters non-public addresses on connection,
+    //     but doing a sync check up-front catches obvious cases
+    //     (`http://127.0.0.1/...`) before we burn a worker on them and
+    //     gives a cleaner 400 instead of a generic connect failure.
+    if let Err(reason) = url_is_publicly_resolvable(&url) {
+        tracing::debug!(url = %url, %reason, "preview blocked by SSRF guard");
+        return StatusCode::BAD_REQUEST.into_response();
+    }
 
     // 4. Try the on-disk cache first.
     let cache_path = extractor.cache_dir.join(format!("{}.jpg", &q.h));
@@ -372,6 +393,139 @@ fn host_of(url: &str) -> Option<String> {
         .rsplit_once(':')
         .map_or(host_with_port, |(h, _)| h);
     Some(host.to_ascii_lowercase())
+}
+
+// ---------------------------------------------------------------------------
+// SSRF guard
+// ---------------------------------------------------------------------------
+//
+// IRC chat is untrusted input. Without this guard, a public channel
+// member could paste `http://127.0.0.1:8443/admin/...`,
+// `http://192.168.1.1/router-config`, or `http://169.254.169.254/...`
+// (cloud metadata) and the server would happily fetch it on behalf of
+// the user. The guard rejects every address that isn't a *publicly*
+// routable unicast IP.
+//
+// Defense in depth:
+// - `url_is_publicly_resolvable` runs synchronously before the request
+//   so obvious cases never reach reqwest.
+// - `PublicOnlyResolver` is wired into the reqwest client and rejects
+//   the same set of addresses for the initial URL *and* every redirect.
+//   This prevents DNS-rebinding (where a domain resolves to a public IP
+//   the first time and a private IP on the next lookup).
+
+/// Validate a URL up-front, before spinning up a fetch task. Performs a
+/// blocking DNS resolution — acceptable here because the handler that
+/// calls this is already on a tokio worker that's about to spawn more
+/// blocking work for image decoding. Returns the failing reason on
+/// rejection.
+fn url_is_publicly_resolvable(raw: &str) -> Result<(), &'static str> {
+    let parsed = reqwest::Url::parse(raw).map_err(|_| "invalid url")?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err("scheme must be http or https");
+    }
+    let host = parsed.host_str().ok_or("missing host")?;
+    // If the host is already an IP literal, validate it directly. (Skips
+    // the DNS step and prevents `http://[::1]/` from sneaking through.)
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return if is_disallowed_ip(&ip) {
+            Err("address is not a public unicast ip")
+        } else {
+            Ok(())
+        };
+    }
+    let port = parsed.port_or_known_default().unwrap_or(80);
+    let addrs: Vec<SocketAddr> = (host, port)
+        .to_socket_addrs()
+        .map_err(|_| "dns resolution failed")?
+        .collect();
+    if addrs.is_empty() {
+        return Err("no addresses resolved");
+    }
+    if addrs.iter().any(|sa| is_disallowed_ip(&sa.ip())) {
+        return Err("address resolves to a non-public ip");
+    }
+    Ok(())
+}
+
+/// Reject loopback, RFC1918 private, link-local, multicast, broadcast,
+/// unspecified (`0.0.0.0` / `::`), CGNAT, documentation, and IPv6
+/// unique-local / IPv4-mapped-IPv6 of any of the above. Anything left is
+/// a publicly routable unicast address — the only thing we let the
+/// server proxy fetch.
+fn is_disallowed_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_multicast()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || v4.is_documentation()
+            {
+                return true;
+            }
+            // CGNAT (RFC 6598): 100.64.0.0/10
+            let o = v4.octets();
+            o[0] == 100 && (64..=127).contains(&o[1])
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_multicast() || v6.is_unspecified() {
+                return true;
+            }
+            let seg = v6.segments();
+            // Unique local fc00::/7
+            if seg[0] & 0xfe00 == 0xfc00 {
+                return true;
+            }
+            // Link-local fe80::/10
+            if seg[0] & 0xffc0 == 0xfe80 {
+                return true;
+            }
+            // IPv4-mapped IPv6 (::ffff:a.b.c.d) — re-check the v4 part.
+            if let Some(v4) = v6.to_ipv4_mapped()
+                && is_disallowed_ip(&IpAddr::V4(v4))
+            {
+                return true;
+            }
+            false
+        }
+    }
+}
+
+/// Reqwest DNS resolver that drops any non-public address. Plugs into
+/// `reqwest::Client::builder().dns_resolver(...)` so every request
+/// (initial URL *and* redirects) is gated.
+struct PublicOnlyResolver;
+
+impl Resolve for PublicOnlyResolver {
+    fn resolve(&self, name: Name) -> Resolving {
+        Box::pin(async move {
+            let host = name.as_str().to_owned();
+            let addrs = tokio::task::spawn_blocking(move || {
+                (host.as_str(), 0u16)
+                    .to_socket_addrs()
+                    .map(Iterator::collect::<Vec<_>>)
+            })
+            .await
+            .map_err(|e| {
+                Box::new(std::io::Error::other(e)) as Box<dyn std::error::Error + Send + Sync>
+            })?
+            .map_err(|e| Box::new(e) as Box<dyn std::error::Error + Send + Sync>)?;
+            let filtered: Vec<SocketAddr> = addrs
+                .into_iter()
+                .filter(|sa| !is_disallowed_ip(&sa.ip()))
+                .collect();
+            if filtered.is_empty() {
+                return Err(Box::new(std::io::Error::other(
+                    "no public unicast addresses for host",
+                )) as Box<dyn std::error::Error + Send + Sync>);
+            }
+            let iter: Addrs = Box::new(filtered.into_iter());
+            Ok(iter)
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -565,5 +719,100 @@ mod tests {
             .unwrap();
         assert_eq!(decoded.width(), 50);
         assert_eq!(decoded.height(), 40);
+    }
+
+    // -- SSRF guard ---------------------------------------------------------
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_loopback() {
+        assert!(is_disallowed_ip(&ip("127.0.0.1")));
+        assert!(is_disallowed_ip(&ip("127.255.255.254")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_rfc1918() {
+        assert!(is_disallowed_ip(&ip("10.0.0.1")));
+        assert!(is_disallowed_ip(&ip("172.16.0.1")));
+        assert!(is_disallowed_ip(&ip("192.168.1.1")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_link_local_and_metadata() {
+        // 169.254.0.0/16 covers both IPv4 link-local and the cloud
+        // metadata endpoint (169.254.169.254). Must be blocked.
+        assert!(is_disallowed_ip(&ip("169.254.169.254")));
+        assert!(is_disallowed_ip(&ip("169.254.0.1")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_cgnat() {
+        assert!(is_disallowed_ip(&ip("100.64.0.1")));
+        assert!(is_disallowed_ip(&ip("100.127.255.254")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_unspecified_and_broadcast() {
+        assert!(is_disallowed_ip(&ip("0.0.0.0")));
+        assert!(is_disallowed_ip(&ip("255.255.255.255")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_multicast_and_documentation() {
+        assert!(is_disallowed_ip(&ip("224.0.0.1")));
+        assert!(is_disallowed_ip(&ip("192.0.2.1")));
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv4() {
+        assert!(!is_disallowed_ip(&ip("8.8.8.8")));
+        assert!(!is_disallowed_ip(&ip("1.1.1.1")));
+        assert!(!is_disallowed_ip(&ip("142.250.78.46"))); // example public IP
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv6_loopback_link_local_ula() {
+        assert!(is_disallowed_ip(&ip("::1")));
+        assert!(is_disallowed_ip(&ip("fe80::1")));
+        assert!(is_disallowed_ip(&ip("fd00::1")));
+        assert!(is_disallowed_ip(&ip("fc00::abcd")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv4_mapped_loopback() {
+        // ::ffff:127.0.0.1 must be blocked just like 127.0.0.1.
+        assert!(is_disallowed_ip(&ip("::ffff:127.0.0.1")));
+        assert!(is_disallowed_ip(&ip("::ffff:192.168.0.1")));
+    }
+
+    #[test]
+    fn ssrf_allows_public_ipv6() {
+        assert!(!is_disallowed_ip(&ip("2606:4700:4700::1111"))); // Cloudflare
+    }
+
+    #[test]
+    fn ssrf_rejects_non_http_scheme() {
+        assert!(url_is_publicly_resolvable("file:///etc/passwd").is_err());
+        assert!(url_is_publicly_resolvable("ftp://example.com/").is_err());
+        assert!(url_is_publicly_resolvable("gopher://example.com/").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_literal_loopback_ip_in_url() {
+        // Catches `http://127.0.0.1/...` and `http://[::1]/...` without
+        // even touching DNS.
+        assert!(url_is_publicly_resolvable("http://127.0.0.1/admin").is_err());
+        assert!(url_is_publicly_resolvable("http://192.168.1.1/").is_err());
+        assert!(url_is_publicly_resolvable("http://[::1]/").is_err());
+        assert!(url_is_publicly_resolvable("http://169.254.169.254/latest").is_err());
+    }
+
+    #[test]
+    fn ssrf_rejects_malformed_url() {
+        assert!(url_is_publicly_resolvable("not a url").is_err());
+        assert!(url_is_publicly_resolvable("https://").is_err());
     }
 }

--- a/src/web/preview.rs
+++ b/src/web/preview.rs
@@ -111,12 +111,19 @@ impl WebPreviewExtractor {
         // stack rebinds. `PublicOnlyResolver` is invoked for every host —
         // initial URL *and* each redirect — so the guard travels with the
         // request.
+        //
+        // **Panic if the builder fails.** A silent fall-through to
+        // `Client::new()` would create a default client *without* the
+        // resolver and redirect limit, completely defeating the SSRF
+        // guard. Better to refuse to start the preview proxy than serve
+        // it unprotected — the only failure modes here are TLS backend
+        // init issues that the user needs to see anyway.
         let http = reqwest::Client::builder()
             .timeout(Duration::from_secs(30))
             .redirect(reqwest::redirect::Policy::limited(5))
             .dns_resolver(Arc::new(PublicOnlyResolver))
             .build()
-            .unwrap_or_else(|_| reqwest::Client::new());
+            .expect("failed to build SSRF-protected HTTP client for /api/preview");
         Self {
             secret,
             max_per_msg,
@@ -483,6 +490,11 @@ fn is_disallowed_ip(ip: &IpAddr) -> bool {
             if seg[0] & 0xffc0 == 0xfe80 {
                 return true;
             }
+            // Documentation 2001:db8::/32 (RFC 3849). `Ipv6Addr::is_documentation`
+            // is unstable on stable Rust, so test the prefix inline.
+            if seg[0] == 0x2001 && seg[1] == 0x0db8 {
+                return true;
+            }
             // IPv4-mapped IPv6 (::ffff:a.b.c.d) — re-check the v4 part.
             if let Some(v4) = v6.to_ipv4_mapped()
                 && is_disallowed_ip(&IpAddr::V4(v4))
@@ -779,6 +791,17 @@ mod tests {
         assert!(is_disallowed_ip(&ip("fe80::1")));
         assert!(is_disallowed_ip(&ip("fd00::1")));
         assert!(is_disallowed_ip(&ip("fc00::abcd")));
+    }
+
+    #[test]
+    fn ssrf_blocks_ipv6_documentation() {
+        // RFC 3849: 2001:db8::/32. Was previously a regression — the
+        // doc comment claimed documentation addresses were blocked but
+        // only IPv4 doc was actually checked.
+        assert!(is_disallowed_ip(&ip("2001:db8::1")));
+        assert!(is_disallowed_ip(&ip("2001:db8:ffff:ffff::1")));
+        // Adjacent prefix must still be allowed.
+        assert!(!is_disallowed_ip(&ip("2001:db9::1")));
     }
 
     #[test]

--- a/web-ui/src/components/chat_view.rs
+++ b/web-ui/src/components/chat_view.rs
@@ -279,19 +279,38 @@ pub fn ChatView() -> impl IntoView {
     }
 }
 
+/// LocalStorage key that mirrors the server's `web.image_previews` setting
+/// for individual browsers. When set to `"false"`, this client suppresses
+/// previews even if the server has them enabled. Any other value (missing,
+/// `"true"`, etc.) means "show them". No UI toggle yet — power users flip
+/// it from devtools; a Settings panel toggle is the obvious follow-up.
+const IMAGE_PREVIEWS_TOGGLE_KEY: &str = "web_image_previews_enabled";
+
+/// Read the per-browser image-previews override. Returns `true` (show) when
+/// the key is absent or any value other than the literal `"false"`.
+fn previews_enabled_in_browser() -> bool {
+    let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) else {
+        return true;
+    };
+    !matches!(
+        storage.get_item(IMAGE_PREVIEWS_TOGGLE_KEY),
+        Ok(Some(ref v)) if v == "false"
+    )
+}
+
 /// Render the per-message preview block, if there are previews to show.
 ///
 /// Returns `None` (which leptos renders as nothing) when:
 /// - the message has no server-extracted previews,
 /// - every preview is in the dismissed-previews localStorage set, or
-/// - the user has previews disabled in their browser localStorage (future
-///   toggle hook — currently always enabled when the server enables them).
+/// - the user has previews disabled in their browser via the
+///   `web_image_previews_enabled = "false"` localStorage key.
 fn render_previews(
     state: AppState,
     msg_id: u64,
     previews: Vec<crate::protocol::LinkPreview>,
 ) -> Option<leptos::prelude::AnyView> {
-    if previews.is_empty() {
+    if previews.is_empty() || !previews_enabled_in_browser() {
         return None;
     }
     let dismissed = state.dismissed_previews.get();

--- a/web-ui/src/components/input.rs
+++ b/web-ui/src/components/input.rs
@@ -120,16 +120,20 @@ const SETTING_PATHS: &[&str] = &[
     "web.bind_address",
     "web.cloudflare_tunnel_name",
     "web.enabled",
+    "web.image_previews",
+    "web.image_previews_max_per_msg",
     "web.line_height",
     "web.nick_column_width",
     "web.nick_max_length",
     "web.password",
     "web.port",
-    "web.session_hours",
+    "web.session_days",
     "web.theme",
+    "web.thumbnail_cache_mb",
     "web.timestamp_format",
     "web.tls_cert",
     "web.tls_key",
+    "web.username",
 ];
 
 #[component]

--- a/web-ui/src/components/login.rs
+++ b/web-ui/src/components/login.rs
@@ -123,4 +123,3 @@ async fn fetch_login_info() -> Option<String> {
     let json: serde_json::Value = resp.json().await.ok()?;
     json["username"].as_str().map(str::to_owned)
 }
-


### PR DESCRIPTION
Follow-up to #4. Addresses macroscope review findings.

## High — SSRF on `/api/preview`

A public IRC channel could paste `http://127.0.0.1:8443/admin`, `http://192.168.1.1/router-config`, or `http://169.254.169.254/metadata` and the server would happily fetch it (and any HTTP redirect target) on the user's behalf.

Defense in depth:
1. `url_is_publicly_resolvable` runs synchronously before the request — rejects non-`http(s)` schemes, refuses literal loopback / RFC1918 / link-local IPs in the URL, and does DNS resolution + IP filtering for hostnames.
2. `PublicOnlyResolver` is a custom `reqwest::dns::Resolve` plugged into the preview HTTP client. It re-runs the same address filter on every host lookup, so it gates the **initial URL and every redirect** — closes DNS-rebinding where a domain resolves public on first probe, private on second.
3. `redirect::Policy::limited(5)` caps redirect depth so an attacker can't stack rebinds beyond the policy's reach.

Blocked address classes (v4 + v6): loopback, RFC1918 private, link-local (incl. cloud metadata `169.254.169.254`), CGNAT, multicast, broadcast, unspecified, IPv4 documentation, IPv6 ULA, IPv4-mapped-IPv6 of any of the above.

13 new unit tests in `web::preview::tests` (`ssrf_*`).

## Medium — stale `web.session_hours` references

- `web-ui/src/components/input.rs` `/set` autocomplete: replaced `session_hours` with `session_days`; added `username`, `image_previews`, `image_previews_max_per_msg`, `thumbnail_cache_mb`.
- `docs/src/content/web-frontend.md` and `docs/web-frontend.html` config tables updated.

## Low — `git diff --check` whitespace

Trimmed the trailing empty line at the end of `web-ui/src/components/login.rs`.

## Low — client-side previews toggle promised by spec

`render_previews` now honours the `web_image_previews_enabled` localStorage key. Setting it to `\"false\"` hides thumbnails on this browser even if the server has them enabled. Power-user knob for now; a Settings panel toggle is a separate follow-up.

## Test plan

- [x] `cargo test -p repartee` — **1127 / 1127 pass** (+13 SSRF tests)
- [x] `cargo clippy -p repartee --all-targets` — no new warnings (baseline unchanged)
- [x] `cargo check -p repartee-web --target wasm32-unknown-unknown` — clean
- [ ] Manual: paste \`http://127.0.0.1/\` in a channel with previews on; confirm /api/preview returns 400 (was: connects and either succeeds or hangs on timeout)
- [ ] Manual: paste \`http://169.254.169.254/latest/meta-data/\` (cloud metadata); confirm same 400
- [ ] Manual: set \`localStorage.web_image_previews_enabled = \"false\"\`; confirm no thumbnails render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add SSRF guard to `/api/preview` with public-only DNS resolver
> - Introduces `PublicOnlyResolver` in [`preview.rs`](https://github.com/outragedevs/repartee/pull/5/files#diff-1365fa9c8f0b6014ac248618e5ef97af581c1af6b0c65ec32473c4570aa63b25), a custom reqwest DNS resolver that filters out loopback, private, link-local, multicast, and other non-public addresses before any HTTP request is made.
> - Adds a `url_is_publicly_resolvable` pre-check in the preview handler that validates scheme (http/https) and DNS resolution; invalid or private URLs return HTTP 400.
> - Limits redirects to 5 hops in the preview HTTP client.
> - Adds a localStorage-based toggle (`web_image_previews_enabled`) so per-browser image preview visibility can be disabled from the client side.
> - Updates tab completion and docs to reflect renamed setting `web.session_days` and new settings `web.image_previews`, `web.image_previews_max_per_msg`, `web.thumbnail_cache_mb`, and `web.username`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92d6ebf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->