### PR TITLE
fix(web): close SSRF via og:image URL in fetch_image phase 2

### DIFF
--- a/src/image_preview/fetch.rs
+++ b/src/image_preview/fetch.rs
@@ -31,6 +31,9 @@ static OG_IMAGE_RE: LazyLock<Regex> = LazyLock::new(|| {
 // Configuration
 // ---------------------------------------------------------------------------
 
+/// Validator function pointer signature for [`FetchConfig::url_validator`].
+pub type UrlValidator = fn(&str) -> Result<(), &'static str>;
+
 /// Parameters that govern how image fetching behaves.
 #[derive(Debug, Clone)]
 pub struct FetchConfig {
@@ -38,6 +41,20 @@ pub struct FetchConfig {
     pub timeout_secs: u32,
     /// Maximum response body size in bytes.
     pub max_file_size: u64,
+    /// Optional URL validator invoked **before every `client.get(url)`**.
+    /// Errors here short-circuit the fetch with [`FetchError::BlockedUrl`].
+    ///
+    /// Set by the web preview pipeline to enforce the SSRF guard against
+    /// both the initial URL **and** any `og:image` URL scraped from a
+    /// page body. The custom redirect policy on the reqwest client gates
+    /// redirect targets; the URL validator gates new requests started
+    /// from inside this module (`fetch_image` does a second request for
+    /// the og:image after parsing the page HTML).
+    ///
+    /// `None` (the default) preserves backwards-compatible behaviour for
+    /// the TUI image preview, where the user types URLs themselves and
+    /// the threat model is different.
+    pub url_validator: Option<UrlValidator>,
 }
 
 impl Default for FetchConfig {
@@ -45,6 +62,7 @@ impl Default for FetchConfig {
         Self {
             timeout_secs: 30,
             max_file_size: 10_485_760, // 10 MiB
+            url_validator: None,
         }
     }
 }
@@ -82,6 +100,9 @@ pub enum FetchError {
 
     #[error("invalid URL: {0}")]
     InvalidUrl(String),
+
+    #[error("blocked URL: {0}")]
+    BlockedUrl(String),
 }
 
 // ---------------------------------------------------------------------------
@@ -152,6 +173,17 @@ async fn fetch_url(
     config: &FetchConfig,
     client: &Client,
 ) -> Result<(Vec<u8>, String, String), FetchError> {
+    // SSRF guard: runs before every reqwest `get()` so a phase-2 og:image
+    // URL — which is *not* a redirect target and therefore not gated by
+    // the reqwest redirect policy — gets the same check. Hyper bypasses
+    // the DNS resolver for IP literals, so the validator is the only
+    // thing stopping `<meta property="og:image" content="http://127.0.0.1/...">`.
+    if let Some(validator) = config.url_validator
+        && let Err(reason) = validator(url)
+    {
+        return Err(FetchError::BlockedUrl(reason.to_owned()));
+    }
+
     let response = client
         .get(url)
         .header(reqwest::header::USER_AGENT, USER_AGENT)
@@ -411,6 +443,47 @@ mod tests {
         let config = FetchConfig::default();
         assert_eq!(config.timeout_secs, 30);
         assert_eq!(config.max_file_size, 10_485_760);
+        assert!(
+            config.url_validator.is_none(),
+            "default validator stays off so TUI image preview keeps working"
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_url_short_circuits_on_validator_reject() {
+        // Validator rejects every URL → fetch_url returns BlockedUrl
+        // without making any HTTP request.
+        fn reject_all(_url: &str) -> Result<(), &'static str> {
+            Err("nope")
+        }
+        let cfg = FetchConfig {
+            url_validator: Some(reject_all),
+            ..FetchConfig::default()
+        };
+        let client = Client::new();
+        let err = fetch_url("https://example.invalid/", &cfg, &client)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, FetchError::BlockedUrl(_)));
+    }
+
+    #[tokio::test]
+    async fn fetch_url_runs_validator_with_actual_url() {
+        // Validator should see the URL it was passed.
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static SEEN: AtomicBool = AtomicBool::new(false);
+        fn check(url: &str) -> Result<(), &'static str> {
+            if url == "http://127.0.0.1/sneaky" {
+                SEEN.store(true, Ordering::SeqCst);
+            }
+            Err("blocked")
+        }
+        let cfg = FetchConfig {
+            url_validator: Some(check),
+            ..FetchConfig::default()
+        };
+        let _ = fetch_url("http://127.0.0.1/sneaky", &cfg, &Client::new()).await;
+        assert!(SEEN.load(Ordering::SeqCst));
     }
 
     // -- FetchError display -------------------------------------------------

--- a/src/image_preview/mod.rs
+++ b/src/image_preview/mod.rs
@@ -176,6 +176,7 @@ async fn fetch_image_data(
     let fetch_config = fetch::FetchConfig {
         timeout_secs: config.fetch_timeout,
         max_file_size: config.max_file_size,
+        url_validator: None,
     };
     let result = fetch::fetch_image(url, &fetch_config, client).await?;
 

--- a/src/web/preview.rs
+++ b/src/web/preview.rs
@@ -275,7 +275,17 @@ pub async fn preview_handler(
 
     // 5. Cache miss — fetch + thumbnail. Run the CPU-bound decode/encode
     //    on a blocking thread so the runtime stays responsive.
-    let fetch_cfg = FetchConfig::default();
+    //
+    //    `url_validator` is set so the og:image phase inside
+    //    `fetch_image` re-runs the same shape check on the URL it
+    //    scrapes out of the page HTML. Without that, an attacker page
+    //    could embed `<meta property="og:image" content="http://127.0.0.1/...">`
+    //    and reach localhost (the redirect policy doesn't fire because
+    //    the og:image fetch is a fresh request, not a redirect).
+    let fetch_cfg = FetchConfig {
+        url_validator: Some(validate_url_shape_str),
+        ..FetchConfig::default()
+    };
     let result = match fetch_image(&url, &fetch_cfg, &extractor.http).await {
         Ok(r) => r,
         Err(e) => {
@@ -462,6 +472,14 @@ fn url_is_publicly_resolvable(raw: &str) -> Result<(), &'static str> {
         return Err("address resolves to a non-public ip");
     }
     Ok(())
+}
+
+/// String wrapper around [`validate_url_shape`] suitable for use as the
+/// `url_validator` function pointer on [`FetchConfig`]. Parses the URL
+/// and delegates to the typed function.
+fn validate_url_shape_str(url: &str) -> Result<(), &'static str> {
+    let parsed = reqwest::Url::parse(url).map_err(|_| "invalid url")?;
+    validate_url_shape(&parsed)
 }
 
 /// DNS-free URL validation: scheme is http/https and, when the host is
@@ -965,6 +983,21 @@ mod tests {
         // Hostnames pass the shape check; the DNS resolver does the
         // real work when the connection opens.
         assert!(validate_url_shape(&parse("https://example.com/x")).is_ok());
+    }
+
+    #[test]
+    fn validate_url_shape_str_wraps_typed_validator() {
+        // The string-form wrapper is what FetchConfig.url_validator
+        // calls inside fetch_url. Must accept good URLs and reject the
+        // same things the typed version does.
+        assert!(validate_url_shape_str("https://example.com/x.png").is_ok());
+        assert!(validate_url_shape_str("https://8.8.8.8/x").is_ok());
+        assert!(validate_url_shape_str("http://127.0.0.1/admin").is_err());
+        assert!(validate_url_shape_str("http://[::1]/").is_err());
+        assert!(validate_url_shape_str("http://169.254.169.254/latest").is_err());
+        assert!(validate_url_shape_str("http://192.168.1.1/").is_err());
+        assert!(validate_url_shape_str("file:///etc/passwd").is_err());
+        assert!(validate_url_shape_str("not a url").is_err());
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #6. Bot caught a third SSRF vector.

## The bypass

`fetch_image` is two-phase. Phase 1 fetches the URL; if the response is HTML, phase 2 extracts an `og:image` URL from the body and fetches *that*. The phase-2 fetch is a **fresh request**, not a redirect — the custom redirect policy never runs. Hyper bypasses the DNS resolver for IP literals.

Attack:

1. Attacker controls \`https://attacker.example/page\` (resolves to a public IP, passes initial check).
2. Server fetches it. Response is HTML containing \`<meta property=\"og:image\" content=\"http://127.0.0.1/admin\">\`.
3. \`fetch_image\` extracts the og:image URL and calls \`fetch_url(image_url, ...)\` — a new request.
4. Hyper sees the IP literal, skips the DNS resolver, connects directly. SSRF achieved.

## Fix

New \`url_validator: Option<UrlValidator>\` hook on \`FetchConfig\`. \`fetch_url\` runs the validator before every \`client.get(url)\` — covers initial URL *and* the og:image URL scraped from page HTML. Errors short-circuit with a new \`FetchError::BlockedUrl\` variant.

Web preview wires the validator to \`validate_url_shape_str\` (existing function, now exposed). TUI image preview leaves the validator unset — the user types those URLs themselves and the threat model is different (single-user local input vs public IRC channel feeding the server).

## Test plan

- [x] \`cargo test -p repartee\` — **1139 / 1139 pass** (+3 tests)
- [x] \`cargo clippy -p repartee --all-targets\` — no new warnings
- [ ] Manual: serve a page at \`https://example.test/\` whose body contains \`<meta property=\"og:image\" content=\"http://127.0.0.1/\">\`; paste the page URL in a channel with previews on; confirm /api/preview returns 502 (preview fetch blocked) rather than reaching localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix SSRF via og:image URL by adding a `url_validator` hook to `FetchConfig`
> - Adds a `url_validator: Option<fn(&str) -> Result<(), &'static str>>` field to [`FetchConfig`](https://github.com/outragedevs/repartee/pull/7/files#diff-4c1b3430624690836c7ce69db6034d7892e824ee11953931e642c8f36f4db576) that is called before every HTTP GET, covering both the initial URL and any secondary og:image fetch.
> - Adds a `FetchError::BlockedUrl` variant returned when the validator rejects a URL, short-circuiting the request without making any network call.
> - Wires the existing `validate_url_shape` logic into a new string-wrapper helper [`validate_url_shape_str`](https://github.com/outragedevs/repartee/pull/7/files#diff-1365fa9c8f0b6014ac248618e5ef97af581c1af6b0c65ec32473c4570aa63b25) and passes it as the validator in the preview handler.
> - Risk: The preview handler now returns 502 for requests that would previously have fetched a disallowed og:image URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ff8ad5c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->