### PR TITLE
fix(reload): re-read .env on /reload + shrink restart hint

### DIFF
--- a/src/commands/handlers_admin.rs
+++ b/src/commands/handlers_admin.rs
@@ -10,7 +10,16 @@ use crate::storage;
 const SERVER_ADD_USAGE: &str = "Usage: /server add <id> <address>[:<port>] [port] [-tls] [-notls] [-tlsverify] [-notlsverify] [-auto] [-noauto] [-label=<name>] [-nick=<nick>] [-username=<user>] [-realname=<name>] [-password=<pass>] [-sasl=<user>:<pass>] [-sasl-user=<user>] [-sasl-pass=<pass>] [-sasl-mechanism=<mechanism>] [-channels=<ch1,ch2>] [-bind=<ip>] [-encoding=<codec>] [-autoreconnect=<bool>] [-reconnect-delay=<secs>] [-reconnect-max-retries=<n>] [-autosendcmd=<cmds>] [-client-cert=<path>]";
 
 pub(crate) fn cmd_reload(app: &mut App, _args: &[String]) {
-    // Reload config
+    // Snapshot the pre-reload shrink api_key state so we can detect
+    // a transition from empty → populated and tell the user that
+    // the workers were not spawned at startup and a restart is
+    // required to activate them. (The ShrinkRuntime — client and
+    // worker tasks — is constructed once in App::new_with_mode and
+    // cannot be safely rebuilt from a command handler because the
+    // deliver receiver is owned by the main tokio::select! loop.)
+    let shrink_was_inactive = app.shrink_client.is_none();
+
+    // Reload config.toml
     match crate::config::load_config(&crate::constants::config_path()) {
         Ok(new_config) => {
             app.config = new_config;
@@ -29,6 +38,40 @@ pub(crate) fn cmd_reload(app: &mut App, _args: &[String]) {
         Err(e) => {
             add_local_event(app, &format!("{C_ERR}Failed to reload config: {e}{C_RST}"));
             return;
+        }
+    }
+
+    // Re-read .env and re-apply every credential layer (server
+    // passwords / SASL, web session secret, SHRINK_API_KEY). Without
+    // this step, keys added or rotated in ~/.repartee/.env after
+    // startup stay invisible until the user quits and restarts.
+    // Existing connections keep their already-negotiated credentials;
+    // new /connect attempts (and any code path that re-reads
+    // app.config) pick up the new values.
+    match crate::config::load_env(&crate::constants::env_path()) {
+        Ok(env_vars) => {
+            crate::config::apply_credentials(&mut app.config.servers, &env_vars);
+            crate::config::apply_web_credentials(&mut app.config.web, &env_vars);
+            crate::config::apply_shrink_credentials(&mut app.config.shrink, &env_vars);
+            add_local_event(app, &format!("{C_OK}.env reloaded{C_RST}"));
+
+            // Surface the shrink restart-required edge case: the API
+            // key just appeared in .env but the runtime was built
+            // empty-keyed at startup, so the workers are not running
+            // and the in-process /shrink path stays a no-op until a
+            // full restart. Explicit message beats silent failure.
+            if shrink_was_inactive && !app.config.shrink.api_key.is_empty() {
+                add_local_event(
+                    app,
+                    &format!(
+                        "{C_OK}SHRINK_API_KEY picked up from .env — \
+                         restart repartee to activate the shrink workers{C_RST}"
+                    ),
+                );
+            }
+        }
+        Err(e) => {
+            add_local_event(app, &format!("{C_ERR}Failed to reload .env: {e}{C_RST}"));
         }
     }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -456,7 +456,7 @@ static COMMANDS: LazyLock<Vec<(&'static str, CommandDef)>> = LazyLock::new(|| {
             "reload",
             CommandDef {
                 handler: cmd_reload,
-                description: "Reload theme and config",
+                description: "Reload config, .env credentials, and theme",
                 aliases: &[],
                 category: CommandCategory::Configuration,
             },


### PR DESCRIPTION
## Summary

- `/reload` now re-reads `~/.repartee/.env` (server PASS/SASL, web session secret, `SHRINK_API_KEY`) in addition to `config.toml` and the theme. Reported after adding `SHRINK_API_KEY` post-startup and finding the existing `/reload` did not pick it up.
- When the shrink API key transitions from empty → populated, surface an explicit themed message that a full restart is required to spawn the workers. The `ShrinkRuntime` is built once at startup and cannot be safely rebuilt from a command handler because the deliver receiver is owned by the main `tokio::select!` loop.
- Updated the `/reload` one-line description in the command registry to reflect the broadened scope.

## Test plan

- [x] `cargo check` — clean
- [x] `make clippy` — no new errors
- [x] `make test` — 1181 passed
- [ ] Manual: start repartee without `SHRINK_API_KEY` → add key to `~/.repartee/.env` → `/reload` → expect "SHRINK_API_KEY picked up — restart" message
- [ ] Manual: change `general.theme` in `config.toml` → `/reload` → theme updates as before
- [ ] Manual: change a server `pass` in `.env` → `/reload` → next `/connect` uses the new password

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Re-read `.env` on `/reload` and apply updated credentials
> - `/reload` now calls `config::load_env` after reloading `config.toml`, then re-applies server, web, and shrink credentials from the updated environment.
> - Emits a success event on `.env` reload or an error message on failure.
> - If `SHRINK_API_KEY` appears in the reloaded `.env` while the shrink runtime is inactive, a restart hint is emitted instead of silently ignoring the new key.
> - Updates the `reload` command description in [registry.rs](https://github.com/outragedevs/repartee/pull/9/files#diff-6dafd2b39cdc292f9eb19a8548e00b9dedfae687bd2879454947f58c5a6a2771) to mention `.env` credentials.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 798594d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->