### PR TITLE
fix(ux): fast /wc + multi-target /op|/deop|/voice|/devoice + /kick :reason

### DIFF
--- a/src/commands/handlers_irc.rs
+++ b/src/commands/handlers_irc.rs
@@ -353,9 +353,54 @@ pub(crate) fn cmd_topic(app: &mut App, args: &[String]) {
     }
 }
 
+/// Max nicks accepted on a single `/kick` invocation. Hard cap so a
+/// typo-pasted nick list doesn't fan out into a flood of KICK lines.
+const KICK_MAX_NICKS: usize = 6;
+
+/// Split point for /kick when more than 4 nicks are supplied.
+/// 1..=4 → single KICK line; 5 → `[2, 3]`; 6 → `[2, 4]`. Same
+/// first-line-light reasoning as [`nick_mode_chunk_sizes`].
+fn kick_chunk_sizes(n: usize) -> Vec<usize> {
+    match n {
+        0 => Vec::new(),
+        1..=4 => vec![n],
+        5 => vec![2, 3],
+        6 => vec![2, 4],
+        // Above 6 is rejected at the call site, but degrade gracefully
+        // by spilling everything past the first 2 into a single line.
+        _ => vec![2, n - 2],
+    }
+}
+
+/// Split `remaining` into `(nicks, reason)` using the `:reason` syntax.
+///
+/// Convention: scan for the first token starting with `:`. Everything
+/// before that token is treated as nicks; everything from the colon
+/// onward (with the leading `:` stripped from the first token, then
+/// joined by spaces) is the reason. If no `:` token is present, every
+/// argument is a nick and the reason is `None`. Empty reason after
+/// trimming also collapses to `None`.
+fn parse_kick_args(remaining: &[String]) -> (Vec<String>, Option<String>) {
+    for (i, t) in remaining.iter().enumerate() {
+        if let Some(rest_of_first) = t.strip_prefix(':') {
+            let nicks: Vec<String> = remaining[..i].to_vec();
+            let mut reason_parts = vec![rest_of_first.to_string()];
+            reason_parts.extend(remaining[i + 1..].iter().cloned());
+            let joined = reason_parts.join(" ");
+            let trimmed = joined.trim();
+            let reason = (!trimmed.is_empty()).then(|| trimmed.to_string());
+            return (nicks, reason);
+        }
+    }
+    (remaining.to_vec(), None)
+}
+
 pub(crate) fn cmd_kick(app: &mut App, args: &[String]) {
     if args.is_empty() {
-        add_local_event(app, "Usage: /kick [#channel] <nick> [reason]");
+        add_local_event(
+            app,
+            "Usage: /kick [#channel] <nick> [nick2 ... nick6] [:reason]",
+        );
         return;
     }
 
@@ -364,25 +409,52 @@ pub(crate) fn cmd_kick(app: &mut App, args: &[String]) {
         return;
     };
 
-    // If first arg is a channel, use it; otherwise use current buffer's channel.
-    let (channel, remaining) = if crate::irc::formatting::is_channel(&args[0]) && args.len() >= 2 {
-        (args[0].clone(), &args[1..])
-    } else {
-        let Some(buf) = app.state.active_buffer() else {
-            return;
+    // If first arg is a channel, peel it off; otherwise use the
+    // current buffer's channel.
+    let (channel, remaining): (String, &[String]) =
+        if crate::irc::formatting::is_channel(&args[0]) && args.len() >= 2 {
+            (args[0].clone(), &args[1..])
+        } else {
+            let Some(buf) = app.state.active_buffer() else {
+                return;
+            };
+            (buf.name.clone(), args)
         };
-        (buf.name.clone(), args)
-    };
 
-    let nick = remaining[0].clone();
-    let reason = if remaining.len() > 1 {
-        Some(remaining[1..].join(" "))
-    } else {
-        None
-    };
+    let (nicks, reason) = parse_kick_args(remaining);
 
-    if let Err(e) = sender.send(irc::proto::Command::KICK(channel, nick.clone(), reason)) {
-        add_local_event(app, &format!("Failed to kick {nick}: {e}"));
+    if nicks.is_empty() {
+        add_local_event(app, "Usage: /kick [#channel] <nick> [nick2 ...] [:reason]");
+        return;
+    }
+    if nicks.len() > KICK_MAX_NICKS {
+        add_local_event(
+            app,
+            &format!(
+                "/kick accepts at most {KICK_MAX_NICKS} nicks per invocation \
+                 (received {})",
+                nicks.len()
+            ),
+        );
+        return;
+    }
+
+    // Build the KICK lines. Multi-target KICK uses the comma-list form
+    // (`KICK #chan a,b,c :reason`). All lines are queued back-to-back
+    // into the IRC writer's mpsc with no awaits in between, so the
+    // server receives the whole burst as one transmission.
+    let mut cursor = 0usize;
+    for chunk_size in kick_chunk_sizes(nicks.len()) {
+        let chunk = &nicks[cursor..cursor + chunk_size];
+        cursor += chunk_size;
+        let mut params = vec![channel.clone(), chunk.join(",")];
+        if let Some(ref r) = reason {
+            params.push(r.clone());
+        }
+        if let Err(e) = sender.send(irc::proto::Command::Raw("KICK".to_string(), params)) {
+            add_local_event(app, &format!("Failed to kick {}: {e}", chunk.join(",")));
+            return;
+        }
     }
 }
 
@@ -473,6 +545,41 @@ pub(crate) fn cmd_mode(app: &mut App, args: &[String]) {
     let _ = sender.send(irc::proto::Command::Raw("MODE".to_string(), args.to_vec()));
 }
 
+/// Chunk size sequence for /op /deop /voice /devoice when the user
+/// supplies more nicks than fit in one MODE command.
+///
+/// The rule (matched to irssi/erssi convention): the standard IRC
+/// `MAXMODES=3` limit forces a split whenever there are more than
+/// three targets. The first line carries only 2 nicks, every
+/// subsequent line carries up to 3. Sending in this shape lets the
+/// server burst the full batch in a single tick instead of treating
+/// it as multiple sequential mode changes.
+///
+/// - 1..=3 → `[n]`
+/// - 4 → `[2, 2]`
+/// - 5 → `[2, 3]`
+/// - 6 → `[2, 3, 1]`
+/// - 7 → `[2, 3, 2]`
+/// - 8 → `[2, 3, 3]` … (first 2, then 3-by-3 with remainder)
+fn nick_mode_chunk_sizes(n: usize) -> Vec<usize> {
+    if n == 0 {
+        return Vec::new();
+    }
+    if n <= 3 {
+        return vec![n];
+    }
+    let mut sizes = vec![2usize];
+    let mut remaining = n - 2;
+    while remaining >= 3 {
+        sizes.push(3);
+        remaining -= 3;
+    }
+    if remaining > 0 {
+        sizes.push(remaining);
+    }
+    sizes
+}
+
 fn set_nick_mode(app: &mut App, mode_char: char, adding: bool, args: &[String]) {
     if args.is_empty() {
         let cmd = match (mode_char, adding) {
@@ -500,10 +607,19 @@ fn set_nick_mode(app: &mut App, mode_char: char, adding: bool, args: &[String]) 
     };
 
     let sign = if adding { "+" } else { "-" };
-    let modes: String = std::iter::repeat_n(mode_char, args.len()).collect();
-    let mut cmd_args = vec![channel, format!("{sign}{modes}")];
-    cmd_args.extend(args.iter().cloned());
-    let _ = sender.send(irc::proto::Command::Raw("MODE".to_string(), cmd_args));
+    let mut cursor = 0usize;
+    // All MODE lines are queued into the IRC writer's mpsc back-to-back
+    // with no awaits in between, so the server receives the whole burst
+    // as one transmission — the trick that lets it process e.g. five
+    // ops in the same tick without per-line throttling.
+    for chunk_size in nick_mode_chunk_sizes(args.len()) {
+        let chunk = &args[cursor..cursor + chunk_size];
+        cursor += chunk_size;
+        let modes: String = std::iter::repeat_n(mode_char, chunk.len()).collect();
+        let mut cmd_args = vec![channel.clone(), format!("{sign}{modes}")];
+        cmd_args.extend(chunk.iter().cloned());
+        let _ = sender.send(irc::proto::Command::Raw("MODE".to_string(), cmd_args));
+    }
 }
 
 pub(crate) fn cmd_op(app: &mut App, args: &[String]) {
@@ -1477,7 +1593,62 @@ pub(crate) fn cmd_links(app: &mut App, args: &[String]) {
 
 #[cfg(test)]
 mod tests {
-    use super::list_mode_command_args;
+    use super::{kick_chunk_sizes, list_mode_command_args, nick_mode_chunk_sizes, parse_kick_args};
+
+    fn s(v: &[&str]) -> Vec<String> {
+        v.iter().map(|x| (*x).to_string()).collect()
+    }
+
+    #[test]
+    fn nick_mode_chunk_sizes_follows_two_then_three_rule() {
+        assert_eq!(nick_mode_chunk_sizes(0), Vec::<usize>::new());
+        assert_eq!(nick_mode_chunk_sizes(1), vec![1]);
+        assert_eq!(nick_mode_chunk_sizes(2), vec![2]);
+        assert_eq!(nick_mode_chunk_sizes(3), vec![3]);
+        assert_eq!(nick_mode_chunk_sizes(4), vec![2, 2]);
+        assert_eq!(nick_mode_chunk_sizes(5), vec![2, 3]);
+        assert_eq!(nick_mode_chunk_sizes(6), vec![2, 3, 1]);
+        assert_eq!(nick_mode_chunk_sizes(7), vec![2, 3, 2]);
+        assert_eq!(nick_mode_chunk_sizes(8), vec![2, 3, 3]);
+        assert_eq!(nick_mode_chunk_sizes(9), vec![2, 3, 3, 1]);
+    }
+
+    #[test]
+    fn kick_chunk_sizes_caps_at_six() {
+        assert_eq!(kick_chunk_sizes(0), Vec::<usize>::new());
+        assert_eq!(kick_chunk_sizes(1), vec![1]);
+        assert_eq!(kick_chunk_sizes(4), vec![4]);
+        assert_eq!(kick_chunk_sizes(5), vec![2, 3]);
+        assert_eq!(kick_chunk_sizes(6), vec![2, 4]);
+    }
+
+    #[test]
+    fn parse_kick_args_nicks_only() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice", "bob", "carol"]));
+        assert_eq!(nicks, s(&["alice", "bob", "carol"]));
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn parse_kick_args_with_multiword_reason() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice", "bob", ":be", "nice"]));
+        assert_eq!(nicks, s(&["alice", "bob"]));
+        assert_eq!(reason.as_deref(), Some("be nice"));
+    }
+
+    #[test]
+    fn parse_kick_args_colon_first_token_means_no_nicks() {
+        let (nicks, reason) = parse_kick_args(&s(&[":no", "nicks"]));
+        assert!(nicks.is_empty());
+        assert_eq!(reason.as_deref(), Some("no nicks"));
+    }
+
+    #[test]
+    fn parse_kick_args_empty_reason_collapses_to_none() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice", ":", "   "]));
+        assert_eq!(nicks, s(&["alice"]));
+        assert_eq!(reason, None);
+    }
 
     #[test]
     fn list_mode_command_args_batches_reop_except_and_invex_adds() {

--- a/src/commands/handlers_ui.rs
+++ b/src/commands/handlers_ui.rs
@@ -198,7 +198,14 @@ pub(crate) fn cmd_close(app: &mut App, args: &[String]) {
             app.state.remove_buffer(&buf_id);
         }
         crate::state::buffer::BufferType::Channel => {
-            // Send PART for channels
+            // Irssi-style fast close: drop the buffer locally first so
+            // the UI reacts instantly, then fire-and-forget PART to the
+            // server. We do NOT wait for the server-side echo before
+            // removing the buffer — on a laggy link the previous
+            // behaviour kept a dead window visible for seconds. The
+            // echo handler `handle_part` in irc/events.rs also calls
+            // `remove_buffer`; that call is now a no-op because the
+            // buffer is already gone (remove_buffer is idempotent).
             let reason = if args.is_empty() {
                 "Window closed".to_string()
             } else {
@@ -208,10 +215,8 @@ pub(crate) fn cmd_close(app: &mut App, args: &[String]) {
                 let _ = handle
                     .sender
                     .send(irc::proto::Command::PART(buf_name, Some(reason)));
-            } else {
-                // Already disconnected — just remove
-                app.state.remove_buffer(&buf_id);
             }
+            app.state.remove_buffer(&buf_id);
         }
         crate::state::buffer::BufferType::Query | crate::state::buffer::BufferType::DccChat => {
             // DCC chat buffers close like query buffers — just remove locally.

--- a/src/commands/parser.rs
+++ b/src/commands/parser.rs
@@ -5,7 +5,11 @@ pub struct ParsedCommand {
 
 /// Greedy commands: the last arg consumes the rest of the line.
 /// - me, quit, close, quote: single arg (entire rest)
-/// - msg, query, notice, topic, kick, kb, disconnect, set, alias: two args (first word, rest)
+/// - msg, query, notice, topic, kb, disconnect, set, alias: two args (first word, rest)
+///
+/// `kick` is intentionally NOT greedy: it accepts multiple nicks plus an
+/// optional `:reason` (everything from the first `:`-prefixed token onward).
+/// The handler reconstructs the reason from the tokenised args.
 const GREEDY_COMMANDS: &[&str] = &[
     "msg",
     "query",
@@ -13,7 +17,6 @@ const GREEDY_COMMANDS: &[&str] = &[
     "me",
     "quit",
     "topic",
-    "kick",
     "kb",
     "close",
     "disconnect",

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -129,7 +129,7 @@ static COMMANDS: LazyLock<Vec<(&'static str, CommandDef)>> = LazyLock::new(|| {
             "kick",
             CommandDef {
                 handler: cmd_kick,
-                description: "Kick a user from channel",
+                description: "Kick up to 6 users from channel (use :reason for multi-word reason)",
                 aliases: &["k"],
                 category: CommandCategory::Channel,
             },

--- a/src/state/events.rs
+++ b/src/state/events.rs
@@ -81,6 +81,15 @@ impl AppState {
     }
 
     pub fn remove_buffer(&mut self, id: &str) {
+        // Idempotent: callers may invoke this twice for the same buffer
+        // — e.g. `/wc` removes the channel buffer immediately for an
+        // instant UI close, then the server's PART echo runs
+        // `handle_part` which also calls remove_buffer. Without this
+        // guard the web frontend would receive a second `BufferClosed`
+        // for an already-gone buffer.
+        if !self.buffers.contains_key(id) {
+            return;
+        }
         let was_active = self.active_buffer_id.as_deref() == Some(id);
         self.pending_web_events
             .push(crate::web::protocol::WebEvent::BufferClosed {


### PR DESCRIPTION
## Summary

Three user-requested UX/correctness fixes on a single branch (intended to be the first of several cosmetic PRs).

### 1. `/wc` closes the channel buffer instantly

`cmd_close` previously sent PART and waited for the server-side echo before removing the buffer locally — on a laggy link, a dead window stayed visible for seconds. Now we drop the buffer immediately and fire-and-forget PART (irssi/erssi behaviour). `state::remove_buffer` is now idempotent, so the eventual PART echo (`handle_part` also calls `remove_buffer`) becomes a clean no-op and the web frontend does not get a duplicate `BufferClosed` event.

### 2. `/op` `/deop` `/voice` `/devoice` no longer silently drop nicks past 3

Servers cap parameter modes at `MAXMODES` (default 3); the previous handler packed every nick into a single MODE line and silently truncated. The new `nick_mode_chunk_sizes` helper splits per the irssi convention — first line carries **2** nicks, every subsequent line up to **3**:

| n | chunks |
|---|--------|
| 1..=3 | `[n]` |
| 4 | `[2, 2]` |
| 5 | `[2, 3]` |
| 6 | `[2, 3, 1]` |
| 7 | `[2, 3, 2]` |
| 8 | `[2, 3, 3]` |
| 9 | `[2, 3, 3, 1]` |

All MODE lines are queued back-to-back into the IRC writer's mpsc with no awaits between sends — the server receives the full burst as one transmission and the "first line short, rest full" shape lets it apply five-plus ops in a single tick.

### 3. `/kick` supports up to 6 nicks + multi-word `:reason`

- `kick` removed from `GREEDY_COMMANDS` so multiple nicks tokenise naturally.
- Reason is everything from the first `:`-prefixed token onward (leading `:` stripped, rest joined). No `:` token → every arg is a nick and reason is `None`.
- Hard cap **6** nicks; over the cap is rejected with a themed error rather than silently truncated.
- `kick_chunk_sizes`: `1..=4` → single line, `5` → `[2, 3]`, `6` → `[2, 4]`. Multi-target uses the comma-list form `KICK #chan a,b,c :reason`. All KICK lines queued back-to-back, same burst reasoning.

## Test plan

- [x] `cargo check` clean
- [x] `make clippy` no new errors
- [x] `make test` — **1187 passed** (+6 new for `nick_mode_chunk_sizes`, `kick_chunk_sizes`, and `parse_kick_args`)
- [ ] Manual: `/wc` on a channel — buffer disappears instantly even on a slow connection
- [ ] Manual: `/op a b c d e` on a channel — server applies all 5 ops in one mode burst
- [ ] Manual: `/kick alice bob carol :stop spamming` — single KICK line with comma-list and trailing reason
- [ ] Manual: `/kick a b c d e f :gone` — two KICK lines (`a,b` + `c,d,e,f`) with same reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-target `/kick` with `:reason` support and fix `/op`/`/deop`/`/voice`/`/devoice` for more than 3 nicks
> - `/kick` now accepts up to 6 nicks and an optional `:reason`, sending comma-list `KICK` lines split into chunks (1–4 as one line, 5 as [2,3], 6 as [2,4]) via `Raw("KICK", ...)` in [handlers_irc.rs](https://github.com/outragedevs/repartee/pull/10/files#diff-2bb9a233a8f7c0887dd454b3ce1c6f264844d2753fe087f501ff0a235c5842d6)
> - `/op`, `/deop`, `/voice`, and `/devoice` now split `MODE` commands into multiple lines when more than 3 nicks are provided, using a 2-then-3 chunking strategy
> - `/kick` is removed from the greedy command list in [parser.rs](https://github.com/outragedevs/repartee/pull/10/files#diff-6ab8c8c59f718eabd70ae96b617c95d8b10e144c5ac0bb3d264f955484152f47) so the handler can reconstruct the optional `:reason` from tokenized args
> - Closing a channel buffer in [handlers_ui.rs](https://github.com/outragedevs/repartee/pull/10/files#diff-695064b91faa822c6d55a4e4715c3e49cebcf6e5ea0ebaf93672ba0d3b5e4830) now removes it from the UI immediately after queuing `PART`, regardless of connection state
> - `AppState.remove_buffer` in [events.rs](https://github.com/outragedevs/repartee/pull/10/files#diff-291273ed30f572106d381a0e967a6048b741b806b73ddd782ce2175241b7f088) is now idempotent, preventing duplicate `BufferClosed` events on repeated calls
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ac49ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->