### PR TITLE
feat(kick): comma-separated nicks with colon-free reason

### DIFF
--- a/docs/commands/kick.md
+++ b/docs/commands/kick.md
@@ -7,7 +7,7 @@ description: Kick a user from the channel
 
 ## Syntax
 
-    /kick <nick> [reason]
+    /kick [#channel] <nick>[,nick2,...,nick6] [reason]
 
 ## Aliases
 
@@ -15,14 +15,18 @@ description: Kick a user from the channel
 
 ## Description
 
-Kick a user from the current channel. If no reason is given, the
-user's nick is used as the reason. You must be a channel operator
-to use this command.
+Kick one or more users from the current channel (or `#channel` if
+given). Separate multiple nicks with commas — up to six per
+invocation. Everything after the nick list is the reason; no colon
+is needed. If no reason is given, the user's nick is used as the
+reason. You must be a channel operator to use this command.
 
 ## Examples
 
     /kick troll
     /kick spammer Stop spamming
+    /kick alice,bob,carol go away
+    /kick #other troll Get out
     /k troll Get out
 
 ## See Also

--- a/src/commands/handlers_irc.rs
+++ b/src/commands/handlers_irc.rs
@@ -368,34 +368,35 @@ fn kick_chunk_sizes(n: usize) -> Vec<usize> {
     }
 }
 
-/// Split `remaining` into `(nicks, reason)` using the `:reason` syntax.
+/// Split `remaining` into `(nicks, reason)`.
 ///
-/// Convention: scan for the first token starting with `:`. Everything
-/// before that token is treated as nicks; everything from the colon
-/// onward (with the leading `:` stripped from the first token, then
-/// joined by spaces) is the reason. If no `:` token is present, every
-/// argument is a nick and the reason is `None`. Empty reason after
-/// trimming also collapses to `None`.
+/// Convention: the first whitespace token is a comma-separated nick list;
+/// everything after it (joined by spaces) is the reason. No `:` is needed to
+/// delimit the reason — space alone separates nicks from reason, which removes
+/// the ambiguity of space-separated nick lists. A single leading `:` on the
+/// reason is still accepted and stripped for backward compatibility
+/// (`/kick nick :reason`). Empty comma segments (`a,,b`, `a,b,`) are dropped;
+/// an empty reason after trimming collapses to `None`.
 fn parse_kick_args(remaining: &[String]) -> (Vec<String>, Option<String>) {
-    for (i, t) in remaining.iter().enumerate() {
-        if let Some(rest_of_first) = t.strip_prefix(':') {
-            let nicks: Vec<String> = remaining[..i].to_vec();
-            let mut reason_parts = vec![rest_of_first.to_string()];
-            reason_parts.extend(remaining[i + 1..].iter().cloned());
-            let joined = reason_parts.join(" ");
-            let trimmed = joined.trim();
-            let reason = (!trimmed.is_empty()).then(|| trimmed.to_string());
-            return (nicks, reason);
-        }
-    }
-    (remaining.to_vec(), None)
+    let Some((nick_token, reason_parts)) = remaining.split_first() else {
+        return (Vec::new(), None);
+    };
+    let nicks: Vec<String> = nick_token
+        .split(',')
+        .filter(|seg| !seg.is_empty())
+        .map(ToString::to_string)
+        .collect();
+    let joined = reason_parts.join(" ");
+    let reason_str = joined.strip_prefix(':').unwrap_or(&joined).trim();
+    let reason = (!reason_str.is_empty()).then(|| reason_str.to_string());
+    (nicks, reason)
 }
 
 pub(crate) fn cmd_kick(app: &mut App, args: &[String]) {
     if args.is_empty() {
         add_local_event(
             app,
-            "Usage: /kick [#channel] <nick> [nick2 ... nick6] [:reason]",
+            "Usage: /kick [#channel] <nick>[,nick2,...,nick6] [reason]",
         );
         return;
     }
@@ -420,7 +421,7 @@ pub(crate) fn cmd_kick(app: &mut App, args: &[String]) {
     let (nicks, reason) = parse_kick_args(remaining);
 
     if nicks.is_empty() {
-        add_local_event(app, "Usage: /kick [#channel] <nick> [nick2 ...] [:reason]");
+        add_local_event(app, "Usage: /kick [#channel] <nick>[,nick2,...] [reason]");
         return;
     }
     if nicks.len() > KICK_MAX_NICKS {
@@ -1619,30 +1620,58 @@ mod tests {
     }
 
     #[test]
-    fn parse_kick_args_nicks_only() {
-        let (nicks, reason) = parse_kick_args(&s(&["alice", "bob", "carol"]));
+    fn parse_kick_args_single_nick_no_reason() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice"]));
+        assert_eq!(nicks, s(&["alice"]));
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn parse_kick_args_comma_list_multiple_nicks() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice,bob,carol"]));
         assert_eq!(nicks, s(&["alice", "bob", "carol"]));
         assert_eq!(reason, None);
     }
 
     #[test]
-    fn parse_kick_args_with_multiword_reason() {
-        let (nicks, reason) = parse_kick_args(&s(&["alice", "bob", ":be", "nice"]));
-        assert_eq!(nicks, s(&["alice", "bob"]));
+    fn parse_kick_args_reason_needs_no_colon() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice", "be", "nice"]));
+        assert_eq!(nicks, s(&["alice"]));
         assert_eq!(reason.as_deref(), Some("be nice"));
     }
 
     #[test]
-    fn parse_kick_args_colon_first_token_means_no_nicks() {
-        let (nicks, reason) = parse_kick_args(&s(&[":no", "nicks"]));
-        assert!(nicks.is_empty());
-        assert_eq!(reason.as_deref(), Some("no nicks"));
+    fn parse_kick_args_comma_list_with_reason() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice,bob,carol", "go", "away"]));
+        assert_eq!(nicks, s(&["alice", "bob", "carol"]));
+        assert_eq!(reason.as_deref(), Some("go away"));
+    }
+
+    #[test]
+    fn parse_kick_args_leading_colon_stripped_for_backward_compat() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice", ":be", "nice"]));
+        assert_eq!(nicks, s(&["alice"]));
+        assert_eq!(reason.as_deref(), Some("be nice"));
+    }
+
+    #[test]
+    fn parse_kick_args_empty_comma_segments_dropped() {
+        let (nicks, reason) = parse_kick_args(&s(&["alice,,bob,"]));
+        assert_eq!(nicks, s(&["alice", "bob"]));
+        assert_eq!(reason, None);
     }
 
     #[test]
     fn parse_kick_args_empty_reason_collapses_to_none() {
         let (nicks, reason) = parse_kick_args(&s(&["alice", ":", "   "]));
         assert_eq!(nicks, s(&["alice"]));
+        assert_eq!(reason, None);
+    }
+
+    #[test]
+    fn parse_kick_args_empty_input() {
+        let (nicks, reason) = parse_kick_args(&[]);
+        assert!(nicks.is_empty());
         assert_eq!(reason, None);
     }
 

--- a/src/commands/registry.rs
+++ b/src/commands/registry.rs
@@ -138,7 +138,7 @@ static COMMANDS: LazyLock<Vec<(&'static str, CommandDef)>> = LazyLock::new(|| {
             "kick",
             CommandDef {
                 handler: cmd_kick,
-                description: "Kick up to 6 users from channel (use :reason for multi-word reason)",
+                description: "Kick up to 6 users (comma-separate nicks; rest of line is the reason)",
                 aliases: &["k"],
                 category: CommandCategory::Channel,
             },

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -363,10 +363,7 @@ impl InputState {
             self.cursor_pos = self.value.len();
         } else {
             let text = self.value[..self.cursor_pos].to_string();
-            let (text_before, word) = match text.rfind(' ') {
-                Some(pos) => (text[..=pos].to_string(), text[pos + 1..].to_string()),
-                None => (String::new(), text),
-            };
+            let (text_before, word) = split_completion_word(&text);
             if word.is_empty() {
                 return;
             }
@@ -464,6 +461,27 @@ impl InputState {
             });
         }
     }
+}
+
+/// Split `text` (everything left of the cursor) into the prefix-to-complete and
+/// the text preceding it.
+///
+/// The word is the run after the last space; a comma within it acts as a
+/// nick-list separator (e.g. `/kick a,b,<TAB>`), so only the segment after the
+/// last comma is completed while the already-typed nicks stay in `text_before`.
+/// Commands, emotes, and setting paths never contain commas, so this only ever
+/// affects nick completion.
+fn split_completion_word(text: &str) -> (String, String) {
+    let (mut text_before, mut word) = text.rfind(' ').map_or_else(
+        || (String::new(), text.to_string()),
+        |pos| (text[..=pos].to_string(), text[pos + 1..].to_string()),
+    );
+    if let Some(cpos) = word.rfind(',') {
+        let seg = word[cpos + 1..].to_string();
+        text_before.push_str(&word[..=cpos]);
+        word = seg;
+    }
+    (text_before, word)
 }
 
 /// If `word` looks like an emote prefix (`:usm` — one leading colon, no closing
@@ -891,6 +909,28 @@ mod tests {
         input.tab_complete(&[], &[], &[], &[], true);
         // No known emote starts with "zzzzz" -> unchanged.
         assert_eq!(input.value, ":zzzzz");
+    }
+
+    #[test]
+    fn tab_completes_nick_after_comma_keeps_prior_nicks() {
+        let nicks = vec!["alice".to_owned(), "bob".to_owned()];
+        let mut input = InputState::new();
+        // Comma-separated nick list (e.g. `/kick alice,b<TAB>`): only the
+        // segment after the last comma is completed; "alice," is preserved.
+        input.value = "/kick alice,b".to_owned();
+        input.cursor_pos = input.value.len();
+        input.tab_complete(&nicks, &[], &[], &[], false);
+        assert_eq!(input.value, "/kick alice,bob ");
+    }
+
+    #[test]
+    fn tab_completes_first_nick_without_comma_split() {
+        let nicks = vec!["alice".to_owned()];
+        let mut input = InputState::new();
+        input.value = "/kick al".to_owned();
+        input.cursor_pos = input.value.len();
+        input.tab_complete(&nicks, &[], &[], &[], false);
+        assert_eq!(input.value, "/kick alice ");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Make `/kick` unambiguous and colon-free. The first whitespace token is now a **comma-separated nick list**, and everything after it is the reason — so multi-word reasons no longer need a leading `:`. Space alone separates nicks from reason, which removes the old ambiguity of space-separated nick lists.

- Nicks: `rest[0]` split on `,` (empty segments like `a,,b` / `a,b,` dropped).
- Reason: rest of the line, joined by spaces; a single leading `:` is still stripped for backward compatibility (`/kick nick :reason`).
- Tab completion treats a comma as a nick-list separator: `/kick alice,b<TAB>` completes only the segment after the last comma, preserving the already-typed nicks. Word-splitting extracted into `split_completion_word`.
- Channel peel, `KICK_MAX_NICKS = 6` cap, and chunking are unchanged.

```
/kick spammer stop flooding      → nick=spammer,            reason="stop flooding"
/kick alice,bob,carol go away    → nicks=[alice,bob,carol], reason="go away"
/kick #chan nick reason here     → chan=#chan, nick=nick,   reason="reason here"
/kick nick :still works          → strip ':' → reason="still works"
```

## ⚠️ Behaviour change

`/kick a b c` now kicks `a` with reason `"b c"` (previously kicked **a, b and c** with no reason). Multi-target kick is comma-only: `/kick a,b,c reason`. This is the intended fix — documented in `docs/commands/kick.md` and the commit message.

## Test Plan

- [x] `make clippy` — 0 warnings
- [x] `make test` — 1269 passed (8 `parse_kick_args` cases: single/comma-list/reason-no-colon/leading-colon/empty-segments/empty-reason/empty-input; 2 tab-complete cases: comma-split + first-nick)
- [ ] Manual: `/kick a,b,c reason` kicks all three; `/kick nick multi word reason` sends reason without colon; `/kick alice,b<TAB>` completes to `alice,bob`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add comma-separated nick list and colon-free reason to `/kick` with tab-completion support
> - Rewrites `parse_kick_args` in [handlers_irc.rs](https://github.com/outragedevs/repartee/pull/16/files#diff-2bb9a233a8f7c0887dd454b3ce1c6f264844d2753fe087f501ff0a235c5842d6) to treat the first whitespace-separated token as a comma-separated nick list (up to six nicks) and the remainder of the line as the reason, without requiring a leading `:`.
> - Strips a leading `:` from the reason for backward compatibility; empty reasons collapse to `None`.
> - Updates tab-completion in [input.rs](https://github.com/outragedevs/repartee/pull/16/files#diff-23b6a00db297a01d2ebadfb57df153473bc1a589dd1695e6f6d7a3a3531b656c) via a new `split_completion_word` helper so that pressing Tab completes only the nick segment after the last comma, preserving earlier nicks (e.g. `/kick alice,b<TAB>` → `/kick alice,bob `).
> - Updates help strings in [handlers_irc.rs](https://github.com/outragedevs/repartee/pull/16/files#diff-2bb9a233a8f7c0887dd454b3ce1c6f264844d2753fe087f501ff0a235c5842d6) and the command registry in [registry.rs](https://github.com/outragedevs/repartee/pull/16/files#diff-6dafd2b39cdc292f9eb19a8548e00b9dedfae687bd2879454947f58c5a6a2771) to reflect the new syntax.
> - Behavioral Change: `/kick` now parses the first token as the full nick list; previously, each space-separated token before `:` was treated as a nick.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f0501ca.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->