### PR TITLE
feat(help): embed command docs into the binary

### DIFF
--- a/src/commands/docs.rs
+++ b/src/commands/docs.rs
@@ -1,8 +1,17 @@
-//! Command documentation parser — reads docs/commands/*.md into structured help.
-//! Single source of truth for /help output and subcommand tab completion.
+//! Command documentation parser — embeds docs/commands/*.md into the binary and
+//! parses them into structured help. Single source of truth for /help output and
+//! subcommand tab completion.
 
+use rust_embed::Embed;
 use std::collections::HashMap;
 use std::sync::LazyLock;
+
+/// Command docs compiled into the binary. In debug builds rust-embed reads the
+/// files from disk (live-edit without a rebuild); release builds embed them, so
+/// the shipped binary needs no `docs/` directory on disk at runtime.
+#[derive(Embed)]
+#[folder = "docs/commands/"]
+struct HelpAssets;
 
 #[derive(Debug, Clone)]
 pub struct CommandHelp {
@@ -37,66 +46,23 @@ pub fn get_subcommand_names(cmd: &str) -> Vec<&'static str> {
         .unwrap_or_default()
 }
 
-/// Load all command docs from the embedded directory.
+/// Load and parse all command docs embedded via [`HelpAssets`].
+///
+/// Each `<name>.md` becomes a `CommandHelp` keyed by its file stem. Non-`.md`
+/// entries and any file whose bytes are not valid UTF-8 are skipped.
 fn load_all_docs() -> HashMap<String, CommandHelp> {
     let mut map = HashMap::new();
-    let docs_dir = find_docs_dir();
-
-    if let Ok(entries) = std::fs::read_dir(&docs_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().is_some_and(|e| e == "md")
-                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
-                && let Ok(content) = std::fs::read_to_string(&path)
-            {
-                map.insert(stem.to_string(), parse_doc(&content));
-            }
+    for path in HelpAssets::iter() {
+        let Some(stem) = path.strip_suffix(".md") else {
+            continue;
+        };
+        if let Some(file) = HelpAssets::get(&path)
+            && let Ok(content) = std::str::from_utf8(&file.data)
+        {
+            map.insert(stem.to_string(), parse_doc(content));
         }
     }
     map
-}
-
-/// Find the docs/commands directory relative to the binary or manifest.
-fn find_docs_dir() -> std::path::PathBuf {
-    // Try relative to CARGO_MANIFEST_DIR (dev builds)
-    let manifest_dir = option_env!("CARGO_MANIFEST_DIR")
-        .map(std::path::PathBuf::from)
-        .unwrap_or_default();
-    let from_manifest = manifest_dir.join("docs/commands");
-    if from_manifest.is_dir() {
-        return from_manifest;
-    }
-
-    // Try relative to executable
-    if let Ok(exe) = std::env::current_exe()
-        && let Some(parent) = exe.parent()
-    {
-        let from_exe = parent.join("docs/commands");
-        if from_exe.is_dir() {
-            return from_exe;
-        }
-        if let Some(grandparent) = parent.parent() {
-            let from_grandparent = grandparent.join("docs/commands");
-            if from_grandparent.is_dir() {
-                return from_grandparent;
-            }
-            // Two levels up (target/release -> project root)
-            if let Some(great_grandparent) = grandparent.parent() {
-                let from_great_grandparent = great_grandparent.join("docs/commands");
-                if from_great_grandparent.is_dir() {
-                    return from_great_grandparent;
-                }
-            }
-        }
-    }
-
-    // Try current directory
-    let cwd = std::path::PathBuf::from("docs/commands");
-    if cwd.is_dir() {
-        return cwd;
-    }
-
-    from_manifest
 }
 
 /// Parse a single command doc from markdown content.
@@ -329,9 +295,9 @@ Add a new server.
     }
 
     #[test]
-    fn load_docs_dir_exists() {
+    fn load_all_docs_finds_embedded_docs() {
         let docs = load_all_docs();
-        // Should find at least a few docs
+        // Should find at least a few docs from the embedded HelpAssets.
         assert!(!docs.is_empty(), "No command docs found");
         assert!(docs.contains_key("join"), "Missing join doc");
         assert!(docs.contains_key("quit"), "Missing quit doc");


### PR DESCRIPTION
## Summary

Make `/help` fully self-contained — the shipped binary no longer needs a `docs/` directory on disk.

Previously `load_all_docs()` read `docs/commands/*.md` from the filesystem at runtime, searching `CARGO_MANIFEST_DIR`, paths relative to the executable, and the CWD (`src/commands/docs.rs`). A shipped/installed binary therefore needed the `docs/` tree alongside it to render help.

- Embed `docs/commands/` with `rust-embed` — the same pattern already used for `WebAssets` (`src/web/server.rs`) and `EmoteAssets` (`src/emotes/mod.rs`).
- `load_all_docs()` now iterates the embedded assets; `find_docs_dir()` (59 lines of exe-/CWD-relative path probing) is removed.
- Debug builds still read from disk (live-edit docs without a rebuild); release builds embed them.

This was the only app-shipped asset still loaded from the filesystem at runtime. Themes (`include_str!` → first-run write to `~/.repartee/themes/`), the default config (generated in code), web UI, emotes, and logo were already compiled in. Spellcheck dictionaries are intentionally out of scope (large, optional, already download-based via `/spellcheck get`).

## Verification

- `make release` → 26M binary.
- Phrases that exist **only** in doc bodies — `auto-added if missing` (join.md) and `You must be a channel operator` (kick.md) — appear **0 times** in `.rs` source yet are present in the stripped release binary.
- `docs/commands` no longer appears as a runtime path string in the binary (0 occurrences).

## Test Plan

- [x] `make clippy` — 0 warnings
- [x] `make test` — 1269 passed
- [x] Embedding proven via `strings target/release/repartee`
- [ ] Manual: run the installed binary from a directory without `docs/` and confirm `/help join`, `/help kick`, and subcommand tab-completion (`/server <TAB>`) all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Embed command docs into the binary using rust-embed
> - Replaces filesystem-based doc discovery with embedded assets via `rust-embed`, using a new `HelpAssets` struct that compiles `docs/commands/` into the binary at build time.
> - Removes `find_docs_dir`, which previously scanned multiple on-disk paths (manifest-relative, executable-relative, CWD) to locate docs.
> - In release builds, the binary no longer requires a `docs/` directory on disk; in debug builds, `rust-embed` reads from disk as usual.
> - Behavioral Change: `load_all_docs` now skips any files without a `.md` suffix or with non-UTF-8 content, where previously all files in the discovered directory were considered.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17ec449.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->