### PR TITLE
fix: blank inline emotes on cargo-install (ratatui-core pin) + grapheme-aware chat layout (v1.4.1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4408,6 +4408,7 @@ dependencies = [
  "tower",
  "tracing",
  "tracing-subscriber",
+ "unicode-segmentation",
  "unicode-width",
  "uuid",
  "vt100",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4357,7 +4357,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "repartee"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "aes-gcm",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4386,6 +4386,7 @@ dependencies = [
  "postcard",
  "rand 0.10.1",
  "ratatui",
+ "ratatui-core",
  "ratatui-image",
  "rcgen",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ futures = "0.3"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6"
 unicode-width = "0.2"
+unicode-segmentation = "1"
 thiserror = "2.0"
 indexmap = { version = "2", features = ["serde"] }
 regex = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ exclude = [
 
 [dependencies]
 ratatui = "0.30"
+# Pin: ratatui-core 0.1.1 regressed wide-grapheme/skip-cell rendering
+# (emoji/image cells render blank). Held at 0.1.0 until upstream fix.
+ratatui-core = "=0.1.0"
 crossterm = { version = "0.29", features = ["event-stream", "serde"] }
 postcard = { version = "1.1", features = ["use-std"] }
 libc = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "web-ui"]
 
 [package]
 name = "repartee"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "A modern terminal IRC client built with Ratatui and Tokio"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ Full documentation is available at **[repart.ee/docs](https://repart.ee/docs)**.
 
 ## Changelog
 
+### v1.4.1
+
+- **Fix: inline emotes rendered as blank cells on `cargo install` builds.** `ratatui-core 0.1.1` rewrote the buffer's skip/multi-width cell handling, which breaks the skip-cell mechanism `ratatui-image` relies on to draw inline graphics — so emote thumbnails (and the `/emote` picker) showed only one or two images and empty gaps for the rest. Source and CI builds were shielded by `Cargo.lock`, but `cargo install` ignores the lockfile and pulled the newer crate. `ratatui-core` is versioned independently and floats under `ratatui`'s requirement, so the fix pins **`ratatui-core = "=0.1.0"`** directly (pinning the main `ratatui` crate is not enough). macOS/Linux source builds were never affected.
+- **Fix: multi-codepoint emoji in chat are now measured by grapheme cluster.** Line wrapping and inline-emote placement summed per-`char` widths, but ratatui lays text out by grapheme clusters — so a ZWJ family emoji (👨‍👩‍👧), a skin-tone modifier (👍🏽) or a variation-selector glyph (❤️) was mis-measured. This could split an emoji across wrapped lines or position an inline emote image on the wrong cells when such an emoji preceded it on the same line. Both paths now tokenize with `unicode-segmentation` and measure each cluster with `UnicodeWidthStr`, matching ratatui's own layout.
+
 ### v1.4.0
 
 - **Built-in `:name:` emotes — 183 curated GG7 GIFs, embedded in the binary, rendered inline in both the TUI and the web UI.** Type `:usmiech:` (or the English alias `:smile:`) and it renders as an animated emote in place. The TUI composites GIF frames onto a cell-sized, theme-coloured background with an idle-friendly ~20 fps animation clock (pinned sleep, no busy-loop when nothing moves); the web UI serves them as inline `<img>` from `/emotes/{name}.gif`. An **emote picker overlay** (`Ctrl+G`) with keyboard + mouse navigation and graphical thumbnails, plus `/emote` (alias `/emoji`) to insert by name. Tab-completion offers `:name:` prefixes (closing colon + space). Names work in **Polish or English**, case-insensitive, selectable with `/set emotes.lang en|pl`. New `[emotes]` config section (`enabled`, `render` mode). The whole set — GIFs and the PL→EN alias table — is compiled in via `rust-embed`, so nothing is fetched at runtime.

--- a/src/ui/emote_layout.rs
+++ b/src/ui/emote_layout.rs
@@ -9,7 +9,8 @@
 
 use ratatui::layout::Rect;
 use ratatui::text::Line;
-use unicode_width::UnicodeWidthChar;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
 
 /// Width in terminal cells reserved for one emote (square-ish at 1 row tall).
 pub const EMOTE_COLS: usize = 2;
@@ -40,6 +41,18 @@ pub const fn decode_placeholder_index(c: char) -> Option<u32> {
     }
 }
 
+/// Decode a placeholder index from a single grapheme cluster. Placeholders are
+/// single Private Use Area codepoints, so any multi-codepoint grapheme (a real
+/// emoji sequence) is never mistaken for one.
+#[must_use]
+pub fn decode_placeholder_grapheme(g: &str) -> Option<u32> {
+    let mut chars = g.chars();
+    match (chars.next(), chars.next()) {
+        (Some(c), None) => decode_placeholder_index(c),
+        _ => None,
+    }
+}
+
 /// Where one emote should be composited, in absolute screen cells.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EmotePlacement {
@@ -62,9 +75,13 @@ pub fn resolve_placements(lines: &[Line<'_>], area: Rect) -> Vec<EmotePlacement>
         // (index, start_col, width) of the run currently being accumulated.
         let mut run: Option<(u32, usize, usize)> = None;
         for span in &line.spans {
-            for ch in span.content.chars() {
-                let cw = ch.width().unwrap_or(0);
-                if let Some(idx) = decode_placeholder_index(ch) {
+            // Measure by grapheme clusters so the column cursor matches ratatui's
+            // own grapheme-based layout. A per-`char` walk would mis-advance `col`
+            // across multi-codepoint emoji (VS16, flags, skin-tone, ZWJ) in the
+            // surrounding text and place the emote rect on the wrong cells.
+            for g in span.content.graphemes(true) {
+                let cw = UnicodeWidthStr::width(g);
+                if let Some(idx) = decode_placeholder_grapheme(g) {
                     match &mut run {
                         // Extend only within a single emote's width. Two identical
                         // emotes typed back-to-back (`:x::x:`) are the same index,
@@ -185,6 +202,22 @@ mod tests {
         assert_eq!(placements[0].emote_index, 1);
         assert_eq!(placements[1].emote_index, 2);
         assert_eq!(placements[1].rect.x as usize, EMOTE_COLS);
+    }
+
+    #[test]
+    fn placement_x_uses_grapheme_width_of_preceding_emoji() {
+        // A ZWJ family emoji before the placeholder is ONE grapheme of display
+        // width 2 (what ratatui reserves). Summing per-`char` widths would count
+        // it as 6 and push the emote rect to the wrong column.
+        let emoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+        let ph = placeholder_for_index(5);
+        let line = Line::from(vec![Span::raw(emoji.to_owned()), Span::raw(ph)]);
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 40, 1));
+        assert_eq!(placements.len(), 1);
+        assert_eq!(
+            placements[0].rect.x, 2,
+            "preceding ZWJ emoji occupies 2 cells, not 6"
+        );
     }
 
     #[test]

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -23,6 +23,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::prelude::*;
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 pub type Tui = Terminal<CrosstermBackend<Box<dyn Write + Send>>>;
@@ -171,14 +172,18 @@ pub fn wrap_line(line: Line<'static>, width: usize, indent: usize) -> Vec<Line<'
         return vec![line];
     }
 
-    // Flatten to (char, display_width, Style) and measure total width in one pass.
-    let styled_chars: Vec<(char, usize, Style)> = line
+    // Flatten to (grapheme, display_width, Style) and measure total width in one
+    // pass. Tokenizing by grapheme cluster (not `char`) and measuring each with
+    // `UnicodeWidthStr` mirrors how ratatui lays the line out, so multi-codepoint
+    // emoji (VS16, flags, skin-tone, ZWJ) get their real on-screen width and are
+    // never split across a wrap boundary.
+    let styled_chars: Vec<(String, usize, Style)> = line
         .spans
         .iter()
         .flat_map(|span| {
             span.content
-                .chars()
-                .map(move |ch| (ch, ch.width().unwrap_or(0), span.style))
+                .graphemes(true)
+                .map(move |g| (g.to_owned(), UnicodeWidthStr::width(g), span.style))
         })
         .collect();
 
@@ -223,7 +228,7 @@ pub fn wrap_line(line: Line<'static>, width: usize, indent: usize) -> Vec<Line<'
 
         // Try to find a word break point (last space within the chunk).
         let chunk = &styled_chars[pos..end];
-        let break_at = chunk.iter().rposition(|(ch, _, _)| *ch == ' ');
+        let break_at = chunk.iter().rposition(|(g, _, _)| g == " ");
 
         let actual_end = break_at.map_or(end, |break_pos| pos + break_pos + 1);
         // Never split a multi-cell emote placeholder run across the boundary.
@@ -237,7 +242,7 @@ pub fn wrap_line(line: Line<'static>, width: usize, indent: usize) -> Vec<Line<'
         first_line = false;
 
         // Skip leading spaces on continuation lines.
-        while pos < styled_chars.len() && styled_chars[pos].0 == ' ' {
+        while pos < styled_chars.len() && styled_chars[pos].0 == " " {
             pos += 1;
         }
     }
@@ -253,20 +258,20 @@ pub fn wrap_line(line: Line<'static>, width: usize, indent: usize) -> Vec<Line<'
 /// chars, move it back to the run's start so the whole emote wraps as a unit.
 /// Returns the original `end` when the run starts at/before `pos` (the emote is
 /// wider than the line and cannot be kept whole — avoids a zero-progress loop).
-fn avoid_splitting_placeholder(chars: &[(char, usize, Style)], pos: usize, end: usize) -> usize {
-    use crate::ui::emote_layout::decode_placeholder_index;
+fn avoid_splitting_placeholder(chars: &[(String, usize, Style)], pos: usize, end: usize) -> usize {
+    use crate::ui::emote_layout::decode_placeholder_grapheme;
     if end == 0 || end >= chars.len() {
         return end;
     }
-    let Some(idx) = decode_placeholder_index(chars[end].0) else {
+    let Some(idx) = decode_placeholder_grapheme(&chars[end].0) else {
         return end;
     };
-    // Only a split if the char just before the boundary is the same placeholder.
-    if decode_placeholder_index(chars[end - 1].0) != Some(idx) {
+    // Only a split if the cell just before the boundary is the same placeholder.
+    if decode_placeholder_grapheme(&chars[end - 1].0) != Some(idx) {
         return end;
     }
     let mut e = end;
-    while e > pos && decode_placeholder_index(chars[e - 1].0) == Some(idx) {
+    while e > pos && decode_placeholder_grapheme(&chars[e - 1].0) == Some(idx) {
         e -= 1;
     }
     if e <= pos { end } else { e }
@@ -276,7 +281,7 @@ fn avoid_splitting_placeholder(chars: &[(char, usize, Style)], pos: usize, end: 
 /// consecutive chars with the same style into spans.  Prepends `indent` spaces when
 /// `is_continuation` is true.
 fn build_line_from_styled_chars(
-    chars: &[(char, usize, Style)],
+    chars: &[(String, usize, Style)],
     is_continuation: bool,
     indent: usize,
 ) -> Line<'static> {
@@ -293,15 +298,15 @@ fn build_line_from_styled_chars(
     let mut current_text = String::new();
     let mut current_style = chars[0].2;
 
-    for &(ch, _, style) in chars {
-        if style != current_style && !current_text.is_empty() {
+    for (g, _, style) in chars {
+        if *style != current_style && !current_text.is_empty() {
             spans.push(Span::styled(
                 std::mem::take(&mut current_text),
                 current_style,
             ));
-            current_style = style;
+            current_style = *style;
         }
-        current_text.push(ch);
+        current_text.push_str(g);
     }
 
     if !current_text.is_empty() {
@@ -461,6 +466,43 @@ mod wrap_tests {
         assert!(
             result.len() >= 2,
             "CJK should cause wrap at width=5, got {} lines",
+            result.len()
+        );
+    }
+
+    #[test]
+    fn multi_codepoint_emoji_measured_and_kept_whole() {
+        // 👨‍👩‍👧 (man-ZWJ-woman-ZWJ-girl) renders as ONE grapheme cluster of
+        // display width 2 — the same measurement ratatui uses when it lays the
+        // line out. Summing per-`char` widths would count it as 6 columns and
+        // could split the ZWJ sequence across wrapped lines.
+        let emoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
+        let line = Line::from(format!("{emoji}x")); // grapheme width 2 + 1 = 3
+        let result = wrap_line(line, 3, 0);
+        assert_eq!(
+            result.len(),
+            1,
+            "width-3 budget fits emoji(2)+x(1) on one line, got {}",
+            result.len()
+        );
+        assert_eq!(
+            line_text(&result[0]),
+            format!("{emoji}x"),
+            "emoji grapheme must stay intact, never split"
+        );
+    }
+
+    #[test]
+    fn variation_selector_emoji_counts_as_two_columns() {
+        // ❤️ is U+2764 + U+FE0F (VS16); as a grapheme it is width 2, the same as
+        // ratatui measures it. Summing per-`char` widths yields only 1 (VS16 is
+        // width 0), so "a❤️" (3 grapheme columns) would be wrongly kept on one
+        // line at width 2. It must wrap to match what ratatui actually draws.
+        let line = plain_line("a\u{2764}\u{FE0F}");
+        let result = wrap_line(line, 2, 0);
+        assert!(
+            result.len() >= 2,
+            "a + 2-column heart exceeds width 2 and must wrap, got {}",
             result.len()
         );
     }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -219,6 +219,15 @@ pub fn wrap_line(line: Line<'static>, width: usize, indent: usize) -> Vec<Line<'
             end += 1;
         }
 
+        // Guarantee forward progress. An indivisible grapheme wider than the
+        // available width (e.g. a 2-cell emoji or CJK char at width 1) fits
+        // nowhere, leaving `end == pos`. Emit it anyway (overflowing the line) so
+        // `pos` always advances — otherwise the outer loop spins forever, growing
+        // `result` until the process is OOM-killed.
+        if end == pos {
+            end = pos + 1;
+        }
+
         // Last chunk — take everything remaining.
         if end >= styled_chars.len() {
             let built = build_line_from_styled_chars(&styled_chars[pos..], !first_line, indent);
@@ -490,6 +499,18 @@ mod wrap_tests {
             format!("{emoji}x"),
             "emoji grapheme must stay intact, never split"
         );
+    }
+
+    #[test]
+    fn oversized_grapheme_at_width_one_terminates() {
+        // ❤️ is an indivisible 2-cell grapheme; at width 1 it can never "fit", but
+        // the wrapper must still make forward progress (emit it, overflowing the
+        // line) instead of looping forever. Also covers the pre-existing case of a
+        // lone 2-cell char (😀, CJK) at width 1.
+        let line = plain_line("a\u{2764}\u{FE0F}b");
+        let result = wrap_line(line, 1, 0);
+        let joined: String = result.iter().map(line_text).collect();
+        assert_eq!(joined, "a\u{2764}\u{FE0F}b", "all content preserved, no hang");
     }
 
     #[test]


### PR DESCRIPTION
## Why

Inline emotes (and the `/emote` picker) rendered as **blank cells** for users who installed via `cargo install repartee` — only one or two thumbnails showed, the rest were empty gaps. Source builds and macOS were fine, which pointed at a dependency difference, not the terminal/font.

## Root cause

`cargo install` ignores `Cargo.lock` and resolves the newest compatible deps. On 2026-06-05 **`ratatui-core 0.1.1`** shipped (ratatui PR #1605), rewriting the buffer's `skip`/multi-width cell handling — which is exactly the mechanism `ratatui-image` relies on to place inline graphics. Source/CI builds were shielded by the lockfile; `cargo install` was not.

Reproduced deterministically: same machine, same terminal, only the binary's `ratatui-core` version differs → emotes break with `0.1.1`, work with `0.1.0`.

`ratatui-core` is versioned independently (`0.1.x`) and floats under `ratatui`'s `^0.1.0` requirement, so pinning the main `ratatui` crate is **not** enough — a fresh resolve still pulls `0.1.1`. The pin must target `ratatui-core` directly.

## Changes

- **`fix(deps)`** — pin `ratatui-core = "=0.1.0"`. Verified via a fresh (cargo-install-like) resolve that this cascades the whole ratatui set back to the known-good `0.30.0`/`0.1.0` versions, with zero unrelated lockfile churn.
- **`fix(ui)`** — `wrap_line` and `resolve_placements` summed per-`char` widths, but ratatui lays text out by **grapheme clusters** measured with `UnicodeWidthStr`. Multi-codepoint emoji diverge (ZWJ family 👨‍👩‍👧 = 6 by char-sum vs 2 as a grapheme; VS16 ❤️ = 1 vs 2), causing mis-wraps, split sequences, and inline-emote images placed on the wrong cells. Both paths now tokenize with `unicode-segmentation` and measure each cluster, matching ratatui's layout. (Addresses two findings from review; a third — "preserve previous emote placements for cleanup" — was investigated and is a misdiagnosis: `emote_placements` is only consumed for current-frame compositing, not cleanup.)
- **`chore`** — bump to 1.4.1 + changelog.

## Verification

- `make clippy` — 0 warnings
- `make test` — 1272 passed, 0 failed (3 new grapheme tests, RED→GREEN proven)
- `make release` — builds clean
- Empirical width check (`unicode-width 0.2.2`): char-sum vs grapheme str-width confirmed to diverge for VS16/ZWJ/skin-tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix blank inline emotes and incorrect chat layout by switching to grapheme-aware text measurement
> - Pins `ratatui-core = "=0.1.0"` in [Cargo.toml](https://github.com/outragedevs/repartee/pull/18/files#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542) to prevent `ratatui-core 0.1.1` from breaking inline emote rendering on `cargo install`.
> - Switches [src/ui/emote_layout.rs](https://github.com/outragedevs/repartee/pull/18/files#diff-e8cd18467041cc00d5929c2f22407c37ccb8cfda76a0e3b4d59cca19f421f3d4) and [src/ui/mod.rs](https://github.com/outragedevs/repartee/pull/18/files#diff-1b16d2199af085af653f62d275312de8a650ede0fdb65a9d22c1b6d71951d458) from per-char iteration to per-grapheme iteration using `unicode-segmentation`, so multi-codepoint emoji (e.g. ZWJ sequences) are measured and kept whole.
> - Adds `decode_placeholder_grapheme` to safely detect Private Use Area emote placeholders when iterating by grapheme cluster instead of scalar char.
> - Behavioral Change: emote placement x-offsets and line-wrap boundaries now match ratatui's grapheme-based layout; chat lines with multi-codepoint emoji will render differently than before. A too-wide grapheme at a narrow line width now advances past itself instead of looping infinitely.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 573806d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->