### PR TITLE
feat(emotes): size inline emotes to native GIF dimensions + rescale on font change

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,11 @@ Full documentation is available at **[repart.ee/docs](https://repart.ee/docs)**.
 
 ## Changelog
 
+### v1.5.0
+
+- **Inline emotes now size to the GIF, not a fixed box.** Every `:name:` emote was previously crushed into a fixed 2-cell square, so the many wide GG7 animations (e.g. 40×18, 50×20) rendered as a tiny squished strip. Each emote's on-screen footprint is now derived from its native GIF dimensions and the terminal's cell size — preserving aspect ratio and never upscaling past the original — so small square emotes keep their size while wide GIFs span proportionally more columns. Tall GIFs may also span multiple rows: the chat reserves blank rows below the line so the emote grows downward without overlapping following text (and never paints over the input bar). Tunable via `[emotes] max_cols` (default 8) and `max_rows` (default 3); set `max_rows = 1` to keep every emote strictly one row tall.
+- **Inline emotes rescale when you change the terminal font size.** The cell pixel size was detected once at startup, so zooming the terminal in/out left emotes rendered for the old font — correct only near the launch size. A resize now re-derives the cell size and re-renders emotes at the new scale.
+
 ### v1.4.3
 
 - **Web UI: emote/emoji picker now inserts on mobile.** Both the desktop and mobile layouts mount their own composer, so picking an emote routed the inserted `:name:`/emoji to the hidden desktop input; mobile saw nothing. The insertion now targets the visible composer.

--- a/src/app/emote_anim.rs
+++ b/src/app/emote_anim.rs
@@ -61,6 +61,20 @@ impl EmoteAnimator {
         self.protocol_for(picker, emote_index, 0, bg)
     }
 
+    /// Drop every cached protocol image. Call after the terminal cell pixel size
+    /// changes (font resize / reattach): cache keys do not include the cell size,
+    /// so without this the animator keeps serving bitmaps rendered for the old
+    /// font and emotes display at the wrong size.
+    pub fn clear(&mut self) {
+        self.cache.clear();
+    }
+
+    /// Number of cached protocol images (test-only observability for [`clear`]).
+    #[cfg(test)]
+    pub(crate) fn cache_len(&self) -> usize {
+        self.cache.len()
+    }
+
     /// Whether the emote has more than one frame (i.e. actually animates).
     /// Allocation-free — reads the cached `&'static` frame slice directly.
     #[must_use]
@@ -202,5 +216,22 @@ mod tests {
     #[test]
     fn empty_frames_is_zero() {
         assert_eq!(frame_index_of(&frames_with(&[]), 123), 0);
+    }
+
+    #[test]
+    fn clear_empties_the_protocol_cache() {
+        // halfblocks needs no terminal, so the cache can be populated offline.
+        let picker = ratatui_image::picker::Picker::halfblocks();
+        let mut animator = EmoteAnimator::default();
+        let idx = crate::emotes::resolve("usmiech").expect("usmiech exists");
+        assert!(
+            animator.thumbnail(&picker, idx, (0, 0, 0)).is_some(),
+            "thumbnail must build and cache a protocol image"
+        );
+        assert_eq!(animator.cache_len(), 1, "one image cached after thumbnail");
+
+        animator.clear();
+
+        assert_eq!(animator.cache_len(), 0, "clear() must drop every cached image");
     }
 }

--- a/src/app/emote_anim.rs
+++ b/src/app/emote_anim.rs
@@ -14,32 +14,36 @@ type BgRgb = u32;
 
 #[derive(Default)]
 pub struct EmoteAnimator {
-    /// Keyed by (emote, frame, background) so a theme background change produces
-    /// fresh flattened images rather than reusing the old-background ones.
-    cache: HashMap<(u32, usize, BgRgb), StatefulProtocol>,
+    /// Keyed by (emote, frame, background, cols, rows): a theme background change
+    /// or a different cell footprint (font resize, picker grid vs chat) produces
+    /// fresh flattened images rather than reusing wrongly-sized/coloured ones.
+    cache: HashMap<(u32, usize, BgRgb, u16, u16), StatefulProtocol>,
 }
 
 impl EmoteAnimator {
-    /// Get or build the protocol image for one emote frame, with transparent
-    /// pixels alpha-blended onto `bg` (the theme background) so the emote has no
-    /// visible box against the chat background. Returns `None` if undecodable.
+    /// Get or build the protocol image for one emote frame at a `cols × rows`
+    /// cell footprint, with transparent pixels alpha-blended onto `bg` (the theme
+    /// background) so the emote has no visible box against the chat background.
+    /// Returns `None` if undecodable.
     fn protocol_for(
         &mut self,
         picker: &Picker,
         emote_index: u32,
         frame_index: usize,
         bg: (u8, u8, u8),
+        cols: u16,
+        rows: u16,
     ) -> Option<&mut StatefulProtocol> {
         use std::collections::hash_map::Entry;
         let bg_key = u32::from(bg.0) << 16 | u32::from(bg.1) << 8 | u32::from(bg.2);
-        match self.cache.entry((emote_index, frame_index, bg_key)) {
+        match self.cache.entry((emote_index, frame_index, bg_key, cols, rows)) {
             Entry::Occupied(e) => Some(e.into_mut()),
             Entry::Vacant(slot) => {
                 let names = crate::emotes::names();
                 let name = names.get(emote_index as usize)?;
                 let frames = crate::emotes::frames(name)?;
                 let (img, _delay) = frames.get(frame_index)?;
-                let canvas = render_frame_on_bg(picker, img, bg);
+                let canvas = render_frame_on_bg(picker, img, bg, cols, rows);
                 Some(
                     slot.insert(
                         picker.new_resize_protocol(image::DynamicImage::ImageRgba8(canvas)),
@@ -49,16 +53,19 @@ impl EmoteAnimator {
         }
     }
 
-    /// Cached static first-frame protocol image for `emote_index`, flattened onto
-    /// `bg`. For non-animated thumbnails such as the emote picker grid (rendering
-    /// every visible emote animated would be far too much per-frame work).
+    /// Cached static first-frame protocol image for `emote_index` at a `cols ×
+    /// rows` footprint, flattened onto `bg`. For non-animated thumbnails such as
+    /// the emote picker grid (rendering every visible emote animated would be far
+    /// too much per-frame work).
     pub fn thumbnail(
         &mut self,
         picker: &Picker,
         emote_index: u32,
         bg: (u8, u8, u8),
+        cols: u16,
+        rows: u16,
     ) -> Option<&mut StatefulProtocol> {
-        self.protocol_for(picker, emote_index, 0, bg)
+        self.protocol_for(picker, emote_index, 0, bg, cols, rows)
     }
 
     /// Drop every cached protocol image. Call after the terminal cell pixel size
@@ -108,7 +115,7 @@ fn frame_index_of(frames: &[crate::emotes::Frame], elapsed_ms: u128) -> usize {
 }
 
 /// Render an emote frame onto an opaque canvas sized to the *exact pixel
-/// dimensions of its cell rectangle* (`EMOTE_COLS * font_w` × `font_h`), filled
+/// dimensions of its cell rectangle* (`cols * font_w` × `rows * font_h`), filled
 /// with the theme background. The emote is scaled to fit (preserving aspect) and
 /// centered. Because the canvas matches the cell rect's aspect ratio and is fully
 /// painted, no terminal background shows through — not around the emote and not
@@ -122,12 +129,12 @@ fn render_frame_on_bg(
     picker: &Picker,
     img: &image::RgbaImage,
     bg: (u8, u8, u8),
+    cols: u16,
+    rows: u16,
 ) -> image::RgbaImage {
-    use crate::ui::emote_layout::EMOTE_COLS;
-
     let (fw, fh) = picker.font_size();
-    let cw = u32::try_from(EMOTE_COLS).unwrap_or(2) * u32::from(fw.max(1));
-    let ch = u32::from(fh.max(1));
+    let cw = u32::from(cols.max(1)) * u32::from(fw.max(1));
+    let ch = u32::from(rows.max(1)) * u32::from(fh.max(1));
 
     // Scale the emote to fit the cell, preserving aspect ratio.
     let (iw, ih) = (img.width().max(1), img.height().max(1));
@@ -180,7 +187,9 @@ pub fn composite(
             continue;
         };
         let fi = frame_index_of(frames, elapsed_ms);
-        if let Some(proto) = animator.protocol_for(picker, p.emote_index, fi, bg) {
+        if let Some(proto) =
+            animator.protocol_for(picker, p.emote_index, fi, bg, p.rect.width, p.rect.height)
+        {
             // Clear the placeholder cells, then draw the frame on top.
             frame.render_widget(ratatui::widgets::Clear, p.rect);
             frame.render_stateful_widget(StatefulImage::default(), p.rect, proto);
@@ -225,7 +234,7 @@ mod tests {
         let mut animator = EmoteAnimator::default();
         let idx = crate::emotes::resolve("usmiech").expect("usmiech exists");
         assert!(
-            animator.thumbnail(&picker, idx, (0, 0, 0)).is_some(),
+            animator.thumbnail(&picker, idx, (0, 0, 0), 2, 1).is_some(),
             "thumbnail must build and cache a protocol image"
         );
         assert_eq!(animator.cache_len(), 1, "one image cached after thumbnail");

--- a/src/app/input.rs
+++ b/src/app/input.rs
@@ -12,6 +12,22 @@ use crate::ui::layout::UiRegions;
 
 use super::{App, MAX_ALIAS_DEPTH, MAX_PASTE_LINES, expand_alias_template};
 
+/// Derive the terminal's cell pixel size (font width/height) from a window-size
+/// report. Returns `None` when any dimension is zero — many terminals leave the
+/// pixel fields unset, in which case we must keep the previously detected size
+/// rather than divide by or compute a bogus `0`.
+const fn font_size_from_window_px(
+    columns: u16,
+    rows: u16,
+    width_px: u16,
+    height_px: u16,
+) -> Option<(u16, u16)> {
+    if columns == 0 || rows == 0 || width_px == 0 || height_px == 0 {
+        return None;
+    }
+    Some((width_px / columns, height_px / rows))
+}
+
 impl App {
     pub(crate) fn handle_event(&mut self, event: Event) {
         match event {
@@ -21,10 +37,45 @@ impl App {
             Event::Resize(cols, rows) => {
                 self.cached_term_cols = cols;
                 self.cached_term_rows = rows;
+                self.refresh_emote_font_size();
                 self.resize_all_shells();
             }
             _ => {}
         }
+    }
+
+    /// Re-derive the terminal cell pixel size after a resize and, if it changed,
+    /// rebuild the image picker so inline emotes scale to the new font size. The
+    /// emote frame cache is keyed by `(emote, frame, bg)` — not by cell size — so
+    /// it must be cleared, otherwise stale-sized bitmaps would keep rendering.
+    ///
+    /// Pixel size is read from `window_size()` (a `TIOCGWINSZ` ioctl on Unix), not
+    /// by re-querying via stdio: the crossterm event stream owns stdin during the
+    /// session, so a stdio query would race it. Terminals that report a font-size
+    /// change as a resize event update the ioctl's pixel fields, so this catches
+    /// live zoom in/out. Terminals that leave the pixel fields at 0 are left
+    /// untouched (the startup-detected size stands).
+    pub(crate) fn refresh_emote_font_size(&mut self) {
+        let Ok(ws) = crossterm::terminal::window_size() else {
+            return;
+        };
+        let Some(new_size) = font_size_from_window_px(ws.columns, ws.rows, ws.width, ws.height)
+        else {
+            return;
+        };
+        if new_size == self.picker.font_size() {
+            return;
+        }
+        tracing::debug!(
+            old = ?self.picker.font_size(),
+            new = ?new_size,
+            "refreshing picker font_size after resize"
+        );
+        #[expect(deprecated, reason = "only API to set font dimensions on a Picker")]
+        let mut new_picker = ratatui_image::picker::Picker::from_fontsize(new_size);
+        new_picker.set_protocol_type(self.picker.protocol_type());
+        self.picker = new_picker;
+        self.emote_animator.clear();
     }
 
     /// Maximum time (ms) between ESC and follow-up key to treat as ESC+key combo.
@@ -1806,6 +1857,34 @@ fn key_event_to_bytes(key: &event::KeyEvent, app_cursor: bool) -> Vec<u8> {
 mod tests {
     use super::*;
     use crossterm::event;
+
+    // ── font_size_from_window_px tests ──
+
+    #[test]
+    fn font_size_divides_pixels_by_cells() {
+        // 80×24 cells over a 640×384px window => an 8×16px cell.
+        assert_eq!(font_size_from_window_px(80, 24, 640, 384), Some((8, 16)));
+    }
+
+    #[test]
+    fn font_size_tracks_a_larger_font() {
+        // Same grid, a zoomed-in font reports a bigger pixel window => bigger cell.
+        assert_eq!(font_size_from_window_px(80, 24, 800, 480), Some((10, 20)));
+    }
+
+    #[test]
+    fn font_size_none_when_pixels_unreported() {
+        // Terminals that leave the pixel fields at 0 must yield None, not a 0 cell.
+        assert_eq!(font_size_from_window_px(80, 24, 0, 0), None);
+        assert_eq!(font_size_from_window_px(80, 24, 640, 0), None);
+        assert_eq!(font_size_from_window_px(80, 24, 0, 384), None);
+    }
+
+    #[test]
+    fn font_size_none_when_grid_is_zero() {
+        assert_eq!(font_size_from_window_px(0, 24, 640, 384), None);
+        assert_eq!(font_size_from_window_px(80, 0, 640, 384), None);
+    }
 
     // ── expand_alias_template tests ──
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -631,6 +631,10 @@ pub struct EmotesConfig {
     pub render: RenderMode,
     /// Picker / insert preview language.
     pub lang: EmoteLang,
+    /// Maximum width, in terminal cells, an inline emote may occupy. Wide GIFs
+    /// scale up to this many columns (preserving aspect, never past native size)
+    /// instead of being crushed into a fixed 2-cell box.
+    pub max_cols: u16,
 }
 
 impl EmotesConfig {
@@ -649,6 +653,7 @@ impl Default for EmotesConfig {
             enabled: true,
             render: RenderMode::Graphical,
             lang: EmoteLang::En,
+            max_cols: 8,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -635,6 +635,11 @@ pub struct EmotesConfig {
     /// scale up to this many columns (preserving aspect, never past native size)
     /// instead of being crushed into a fixed 2-cell box.
     pub max_cols: u16,
+    /// Maximum height, in terminal rows, an inline emote may occupy. Tall GIFs
+    /// grow up to this many rows (the chat reserves blank rows below the line so
+    /// the emote does not overlap following text). `1` keeps every emote strictly
+    /// inline (no reserved rows).
+    pub max_rows: u16,
 }
 
 impl EmotesConfig {
@@ -654,6 +659,7 @@ impl Default for EmotesConfig {
             render: RenderMode::Graphical,
             lang: EmoteLang::En,
             max_cols: 8,
+            max_rows: 3,
         }
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -748,17 +748,24 @@ mod tests {
         let cfg = AppConfig::default();
         assert!(cfg.emotes.enabled);
         assert_eq!(cfg.emotes.render, RenderMode::Graphical);
+        assert_eq!(cfg.emotes.max_cols, 8);
+        assert_eq!(cfg.emotes.max_rows, 3);
 
         // TOML round-trip preserves the section.
         let toml_str = toml::to_string(&cfg).expect("serialize");
         let back: AppConfig = toml::from_str(&toml_str).expect("deserialize");
         assert_eq!(back.emotes.render, RenderMode::Graphical);
+        assert_eq!(back.emotes.max_cols, 8);
+        assert_eq!(back.emotes.max_rows, 3);
 
-        // Parsing an explicit section.
+        // Parsing an explicit section. An older config without the new sizing
+        // fields must still deserialize, falling back to the defaults.
         let parsed: AppConfig =
             toml::from_str("[emotes]\nenabled = false\nrender = \"text\"\n").unwrap();
         assert!(!parsed.emotes.enabled);
         assert_eq!(parsed.emotes.render, RenderMode::Text);
+        assert_eq!(parsed.emotes.max_cols, 8, "missing max_cols falls back to default");
+        assert_eq!(parsed.emotes.max_rows, 3, "missing max_rows falls back to default");
     }
 
     #[test]

--- a/src/emotes/mod.rs
+++ b/src/emotes/mod.rs
@@ -115,6 +115,35 @@ pub fn bytes(name: &str) -> Option<Cow<'static, [u8]>> {
     EmoteAssets::get(&format!("{stem}.gif")).map(|f| f.data)
 }
 
+/// Native pixel size `(width, height)` of each emote, read once from the GIF
+/// logical-screen descriptor (bytes 6..10) without decoding frames. `(0, 0)`
+/// marks an asset whose header could not be read (never happens for the curated
+/// set, but keeps the index total-mappable). Indexed by registry index.
+static NATIVE_SIZES: LazyLock<Vec<(u16, u16)>> = LazyLock::new(|| {
+    NAMES
+        .iter()
+        .map(|stem| {
+            EmoteAssets::get(&format!("{stem}.gif"))
+                .filter(|f| f.data.len() >= 10 && f.data.starts_with(b"GIF"))
+                .map_or((0, 0), |f| {
+                    let d = &f.data;
+                    (
+                        u16::from_le_bytes([d[6], d[7]]),
+                        u16::from_le_bytes([d[8], d[9]]),
+                    )
+                })
+        })
+        .collect()
+});
+
+/// Native GIF pixel size `(width, height)` for the emote at `index`, or `None`
+/// if the index is out of range. Cheap (cached header read, no frame decode) so
+/// the render path can size each emote from its real dimensions every frame.
+#[must_use]
+pub fn native_size(index: u32) -> Option<(u16, u16)> {
+    NATIVE_SIZES.get(index as usize).copied()
+}
+
 /// One decoded animation frame and its display duration (ms, floored at 20).
 pub type Frame = (image::RgbaImage, u32);
 
@@ -221,6 +250,31 @@ mod tests {
     #[test]
     fn frames_unknown_is_none() {
         assert!(frames("definitely_not_an_emote").is_none());
+    }
+
+    #[test]
+    fn native_size_matches_decoded_frame_dimensions() {
+        // The header read (LE bytes 6..10) must agree with the fully decoded
+        // first frame for several differently-shaped assets — this pins both the
+        // byte offsets and the endianness.
+        for name in ["usmiech", "lol", "ok"] {
+            let idx = resolve(name).unwrap_or_else(|| panic!("{name} resolves"));
+            let (hw, hh) = native_size(idx).expect("native size");
+            let (img, _) = &frames(name).expect("frames")[0];
+            assert_eq!(
+                (u32::from(hw), u32::from(hh)),
+                (img.width(), img.height()),
+                "{name}: header size {hw}x{hh} must match decoded {}x{}",
+                img.width(),
+                img.height()
+            );
+            assert!(hw > 0 && hh > 0, "{name}: non-zero native size");
+        }
+    }
+
+    #[test]
+    fn native_size_out_of_range_is_none() {
+        assert!(native_size(u32::MAX).is_none());
     }
 
     #[test]

--- a/src/ui/chat_view.rs
+++ b/src/ui/chat_view.rs
@@ -43,6 +43,18 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 
     let graphical = app.emotes_graphical();
+    // Per-frame emote sizing from the live terminal cell size + config caps. The
+    // height cap is pinned to one row here; multi-row reservation is wired
+    // separately. `None` in text mode.
+    let emote_sizing = graphical.then(|| {
+        let (font_w, font_h) = app.picker.font_size();
+        crate::ui::emote_layout::EmoteSizing {
+            font_w,
+            font_h,
+            max_cols: app.config.emotes.max_cols,
+            max_rows: 1,
+        }
+    });
     // Emote placements resolved from this frame's visible lines; stored on `app`
     // after the immutable borrow below ends, for the compositing pass.
     let mut placements: Vec<crate::ui::emote_layout::EmotePlacement> = Vec::new();
@@ -94,7 +106,7 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 &app.theme,
                 &app.config,
                 nick_fg,
-                graphical,
+                emote_sizing,
             );
             let wrapped = super::wrap_line(line, total_width, indent);
 
@@ -120,8 +132,12 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
             .collect();
 
         // Resolve inline-emote screen rects before the Paragraph consumes the lines.
-        if graphical {
-            placements = crate::ui::emote_layout::resolve_placements(&visible_lines, area);
+        if let Some(sizing) = emote_sizing {
+            placements = crate::ui::emote_layout::resolve_placements(
+                &visible_lines,
+                area,
+                |idx| sizing.footprint(idx),
+            );
         }
 
         let paragraph = Paragraph::new(visible_lines).style(Style::default().bg(bg));

--- a/src/ui/chat_view.rs
+++ b/src/ui/chat_view.rs
@@ -43,16 +43,15 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
     }
 
     let graphical = app.emotes_graphical();
-    // Per-frame emote sizing from the live terminal cell size + config caps. The
-    // height cap is pinned to one row here; multi-row reservation is wired
-    // separately. `None` in text mode.
+    // Per-frame emote sizing from the live terminal cell size + config caps.
+    // `None` in text mode.
     let emote_sizing = graphical.then(|| {
         let (font_w, font_h) = app.picker.font_size();
         crate::ui::emote_layout::EmoteSizing {
             font_w,
             font_h,
             max_cols: app.config.emotes.max_cols,
-            max_rows: 1,
+            max_rows: app.config.emotes.max_rows,
         }
     });
     // Emote placements resolved from this frame's visible lines; stored on `app`
@@ -109,12 +108,25 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
                 emote_sizing,
             );
             let wrapped = super::wrap_line(line, total_width, indent);
+            // Reserve blank rows below any line carrying a multi-row emote so the
+            // emote's rect spans down without overlapping the next line's text.
+            let wrapped = match emote_sizing {
+                Some(sizing) => crate::ui::emote_layout::reserve_emote_rows(wrapped, |idx| {
+                    sizing.footprint(idx).1
+                }),
+                None => wrapped,
+            };
 
             // Push in reverse so the final deque is in chronological order.
             for wl in wrapped.into_iter().rev() {
                 visual_lines.push_front(wl);
             }
 
+            // The budget check counts the *expanded* lines (reserved blanks
+            // included), so multi-row emotes only make this break fire sooner —
+            // `visual_lines.len()` stays bounded by `needed` (≤ buffer_len *
+            // MAX_WRAPPED_LINES_PER_MSG) plus one message's lines. The v0.8.4 OOM
+            // bound therefore still holds; do not move the reservation after this.
             if visual_lines.len() > needed {
                 break;
             }

--- a/src/ui/emote_layout.rs
+++ b/src/ui/emote_layout.rs
@@ -13,7 +13,52 @@ use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 /// Width in terminal cells reserved for one emote (square-ish at 1 row tall).
+/// Used as the fixed thumbnail footprint in the emote picker grid and as a
+/// fallback; chat rendering sizes each emote per [`emote_footprint`].
 pub const EMOTE_COLS: usize = 2;
+
+/// Compute the cell footprint `(cols, rows)` for an emote from its native GIF
+/// pixel size, the terminal cell pixel size, and the configured caps.
+///
+/// The emote is fit within a `max_cols × max_rows` cell box, preserving aspect
+/// ratio and **never upscaling beyond the GIF's native pixel size**. So a small
+/// emote keeps roughly its real on-screen size (≈ 2×1 today) while a large or
+/// wide GIF grows up to the cap instead of being crushed into a fixed 2×1 box,
+/// which letterboxed wide emotes down to a tiny squished strip.
+#[must_use]
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    reason = "inputs are small positive cell/pixel counts; the ratio is rounded then clamped to [1, cap]"
+)]
+pub fn emote_footprint(
+    native_w: u16,
+    native_h: u16,
+    font_w: u16,
+    font_h: u16,
+    max_cols: u16,
+    max_rows: u16,
+) -> (u16, u16) {
+    let nw = f64::from(native_w.max(1));
+    let nh = f64::from(native_h.max(1));
+    let fw = f64::from(font_w.max(1));
+    let fh = f64::from(font_h.max(1));
+    let max_cols = max_cols.max(1);
+    let max_rows = max_rows.max(1);
+
+    // Fit within the cap box preserving aspect; `min(.., 1.0)` forbids upscaling
+    // past the native pixel size.
+    let cap_w = f64::from(max_cols) * fw;
+    let cap_h = f64::from(max_rows) * fh;
+    let scale = (cap_w / nw).min(cap_h / nh).min(1.0);
+    let disp_w = nw * scale;
+    let disp_h = nh * scale;
+
+    let cols = ((disp_w / fw).round() as u16).clamp(1, max_cols);
+    let rows = ((disp_h / fh).round() as u16).clamp(1, max_rows);
+    (cols, rows)
+}
 
 /// Base of the Private Use Area range we use to mark emote placeholders.
 /// PUA-A (U+F0000..=U+FFFFD) gives ~65k slots; 183 emotes fit easily, and these
@@ -21,13 +66,40 @@ pub const EMOTE_COLS: usize = 2;
 const PUA_BASE: u32 = 0x000F_0000;
 const PUA_MAX: u32 = 0x000F_FFFD;
 
-/// Build the placeholder string for an emote registry index: `EMOTE_COLS`
-/// identical PUA chars, each encoding the index. Identical chars => a contiguous
-/// run of width `EMOTE_COLS` that the resolver collapses back to one emote.
+/// Per-frame inputs that map an emote's native GIF size to a cell footprint:
+/// the terminal cell pixel size (from the image picker) and the configured caps.
+#[derive(Debug, Clone, Copy)]
+pub struct EmoteSizing {
+    pub font_w: u16,
+    pub font_h: u16,
+    pub max_cols: u16,
+    pub max_rows: u16,
+}
+
+impl EmoteSizing {
+    /// Cell footprint `(cols, rows)` for the emote at `emote_index`, reading its
+    /// native GIF size. Unknown indices fall back to a 1×1 minimum.
+    #[must_use]
+    pub fn footprint(self, emote_index: u32) -> (u16, u16) {
+        let (nw, nh) = crate::emotes::native_size(emote_index).unwrap_or((0, 0));
+        emote_footprint(nw, nh, self.font_w, self.font_h, self.max_cols, self.max_rows)
+    }
+}
+
+/// Build the placeholder string for an emote: `cols` identical PUA chars, each
+/// encoding the registry index. Identical chars => a contiguous run of width
+/// `cols` that the resolver collapses back to one emote.
+#[must_use]
+pub fn placeholder_for_emote(index: u32, cols: u16) -> String {
+    let c = char::from_u32(PUA_BASE + index).unwrap_or('\u{FFFD}');
+    std::iter::repeat_n(c, usize::from(cols.max(1))).collect()
+}
+
+/// Fixed-width [`EMOTE_COLS`] placeholder — test helper for wrap/resolve tests.
+#[cfg(test)]
 #[must_use]
 pub fn placeholder_for_index(index: u32) -> String {
-    let c = char::from_u32(PUA_BASE + index).unwrap_or('\u{FFFD}');
-    std::iter::repeat_n(c, EMOTE_COLS).collect()
+    placeholder_for_emote(index, u16::try_from(EMOTE_COLS).unwrap_or(2))
 }
 
 /// Recover the emote registry index from a placeholder char.
@@ -60,11 +132,32 @@ pub struct EmotePlacement {
     pub rect: Rect,
 }
 
+/// An emote placeholder run being accumulated across cells on one line.
+struct Run {
+    idx: u32,
+    /// Column (relative to `area.x`) where the run starts.
+    start: usize,
+    /// Cells accumulated so far.
+    width: usize,
+    /// Target width in cells for this emote (`footprint().0`); caps the run so
+    /// adjacent identical emotes split into separate placements.
+    cols: usize,
+    /// Height in rows for this emote (`footprint().1`).
+    rows: u16,
+}
+
 /// Walk the already-wrapped visible lines and compute the screen rect of each
 /// emote placeholder run. `area` is the chat region; `lines[k]` maps to row
-/// `area.y + k`. Placements whose row exceeds `area` height are dropped.
+/// `area.y + k`. `footprint_of` maps an emote index to its `(cols, rows)` cell
+/// footprint (closure seam so callers supply the live picker/config sizing and
+/// tests stay asset-independent). Placements whose row exceeds `area` height are
+/// dropped.
 #[must_use]
-pub fn resolve_placements(lines: &[Line<'_>], area: Rect) -> Vec<EmotePlacement> {
+pub fn resolve_placements(
+    lines: &[Line<'_>],
+    area: Rect,
+    footprint_of: impl Fn(u32) -> (u16, u16),
+) -> Vec<EmotePlacement> {
     let mut out = Vec::new();
     for (row, line) in lines.iter().enumerate() {
         if row >= area.height as usize {
@@ -72,8 +165,7 @@ pub fn resolve_placements(lines: &[Line<'_>], area: Rect) -> Vec<EmotePlacement>
         }
         let y = area.y + u16::try_from(row).unwrap_or(u16::MAX);
         let mut col: usize = 0;
-        // (index, start_col, width) of the run currently being accumulated.
-        let mut run: Option<(u32, usize, usize)> = None;
+        let mut run: Option<Run> = None;
         for span in &line.spans {
             // Measure by grapheme clusters so the column cursor matches ratatui's
             // own grapheme-based layout. A per-`char` walk would mis-advance `col`
@@ -83,16 +175,23 @@ pub fn resolve_placements(lines: &[Line<'_>], area: Rect) -> Vec<EmotePlacement>
                 let cw = UnicodeWidthStr::width(g);
                 if let Some(idx) = decode_placeholder_grapheme(g) {
                     match &mut run {
-                        // Extend only within a single emote's width. Two identical
-                        // emotes typed back-to-back (`:x::x:`) are the same index,
-                        // so cap each run at EMOTE_COLS to keep them separate
-                        // placements instead of one stretched run.
-                        Some((cur, _start, w)) if *cur == idx && *w + cw <= EMOTE_COLS => {
-                            *w += cw;
+                        // Extend only within this emote's own width. Two identical
+                        // emotes back-to-back (`:x::x:`) share an index, so the
+                        // per-emote `cols` cap keeps them as separate placements
+                        // instead of one stretched run.
+                        Some(r) if r.idx == idx && r.width + cw <= r.cols => {
+                            r.width += cw;
                         }
                         _ => {
                             flush_run(&mut run, y, area.x, &mut out);
-                            run = Some((idx, col, cw));
+                            let (cols, rows) = footprint_of(idx);
+                            run = Some(Run {
+                                idx,
+                                start: col,
+                                width: cw,
+                                cols: usize::from(cols.max(1)),
+                                rows: rows.max(1),
+                            });
                         }
                     }
                 } else {
@@ -106,17 +205,17 @@ pub fn resolve_placements(lines: &[Line<'_>], area: Rect) -> Vec<EmotePlacement>
     out
 }
 
-fn flush_run(
-    run: &mut Option<(u32, usize, usize)>,
-    y: u16,
-    area_x: u16,
-    out: &mut Vec<EmotePlacement>,
-) {
-    if let Some((idx, start, w)) = run.take() {
-        let x = area_x.saturating_add(u16::try_from(start).unwrap_or(u16::MAX));
+fn flush_run(run: &mut Option<Run>, y: u16, area_x: u16, out: &mut Vec<EmotePlacement>) {
+    if let Some(r) = run.take() {
+        let x = area_x.saturating_add(u16::try_from(r.start).unwrap_or(u16::MAX));
         out.push(EmotePlacement {
-            emote_index: idx,
-            rect: Rect::new(x, y, u16::try_from(w).unwrap_or(u16::MAX), 1),
+            emote_index: r.idx,
+            // Width is the cells actually occupied (`r.width`), not the target
+            // footprint (`r.cols`). They are equal for an unsplit run; if the
+            // wrapper had to split an over-wide emote across a line edge, this
+            // fragment must cover only its own cells — the compositor sizes the
+            // image canvas from this rect, so a wider claim would overpaint text.
+            rect: Rect::new(x, y, u16::try_from(r.width).unwrap_or(u16::MAX), r.rows),
         });
     }
 }
@@ -125,6 +224,86 @@ fn flush_run(
 mod tests {
     use super::*;
     use ratatui::text::Span;
+
+    // ── emote_footprint tests (font 8×16, caps 8×3 unless noted) ──
+
+    #[test]
+    fn footprint_small_square_stays_two_by_one() {
+        // A 15×15 GIF (the most common size) keeps today's ~2×1 footprint:
+        // no upscaling, height fits one row.
+        assert_eq!(emote_footprint(15, 15, 8, 16, 8, 3), (2, 1));
+    }
+
+    #[test]
+    fn footprint_wide_emote_gets_more_columns_not_letterboxed() {
+        // A 40×18 banner used to be crushed into 2 cols (≈16×7px, squished).
+        // It should now span ~5 cols at one row tall, preserving its shape.
+        assert_eq!(emote_footprint(40, 18, 8, 16, 8, 3), (5, 1));
+        // A 50×20 GIF spans ~6 cols.
+        assert_eq!(emote_footprint(50, 20, 8, 16, 8, 3), (6, 1));
+    }
+
+    #[test]
+    fn footprint_large_gif_grows_to_multiple_rows_within_cap() {
+        // The biggest asset (64×46) grows to the full 8×3 cap.
+        assert_eq!(emote_footprint(64, 46, 8, 16, 8, 3), (8, 3));
+    }
+
+    #[test]
+    fn footprint_never_exceeds_caps() {
+        // A hypothetical huge GIF is scaled down to fit the cap, never beyond.
+        let (cols, rows) = emote_footprint(2000, 1000, 8, 16, 8, 3);
+        assert!(cols <= 8 && rows <= 3, "got {cols}x{rows}, cap is 8x3");
+        assert!(cols >= 1 && rows >= 1);
+    }
+
+    #[test]
+    fn footprint_max_rows_one_keeps_single_row_but_still_widens() {
+        // With rows capped at 1 (the conservative default), a tall/wide emote
+        // still gets extra columns — it just never grows vertically.
+        let (_, rows) = emote_footprint(64, 46, 8, 16, 8, 1);
+        assert_eq!(rows, 1, "max_rows=1 must force a single row");
+        let (cols, rows2) = emote_footprint(40, 18, 8, 16, 8, 1);
+        assert_eq!(rows2, 1);
+        assert!(cols >= 3, "wide emote still widens at 1 row, got {cols} cols");
+    }
+
+    #[test]
+    fn footprint_is_resilient_to_zero_inputs() {
+        // Degenerate inputs must never divide by zero or return a 0 dimension.
+        let (cols, rows) = emote_footprint(0, 0, 0, 0, 0, 0);
+        assert!(cols >= 1 && rows >= 1);
+    }
+
+    #[test]
+    fn footprint_scales_with_font_size() {
+        // A bigger font (cell 16×32) halves the column count for the same GIF.
+        assert_eq!(emote_footprint(40, 18, 16, 32, 8, 3), (3, 1));
+    }
+
+    #[test]
+    fn resolve_uses_footprint_width_and_splits_adjacent_wide_emotes() {
+        // Two adjacent copies of the same 5-col emote must become two 5-wide
+        // placements, not one 10-wide stretched run.
+        let mut s = placeholder_for_emote(3, 5);
+        s.push_str(&placeholder_for_emote(3, 5));
+        let line = Line::from(Span::raw(s));
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 40, 1), |_| (5, 1));
+        assert_eq!(placements.len(), 2);
+        assert_eq!(placements[0].rect.width, 5);
+        assert_eq!(placements[1].rect.width, 5);
+        assert_eq!(placements[0].rect.x, 0);
+        assert_eq!(placements[1].rect.x, 5);
+    }
+
+    #[test]
+    fn resolve_sets_rect_height_from_footprint_rows() {
+        let line = Line::from(Span::raw(placeholder_for_emote(2, 4)));
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 40, 3), |_| (4, 3));
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].rect.width, 4);
+        assert_eq!(placements[0].rect.height, 3);
+    }
 
     #[test]
     fn encode_then_decode_roundtrips_index() {
@@ -154,7 +333,7 @@ mod tests {
         let line = Line::from(vec![Span::raw("ab"), Span::raw(ph), Span::raw("c")]);
         let area = Rect::new(10, 4, 40, 5);
 
-        let placements = resolve_placements(&[line], area);
+        let placements = resolve_placements(&[line], area, |_| (2, 1));
         assert_eq!(placements.len(), 1);
         let p = &placements[0];
         assert_eq!(p.emote_index, 5);
@@ -169,7 +348,7 @@ mod tests {
         let ph = placeholder_for_index(1);
         let lines = vec![Line::from(Span::raw(ph.clone())), Line::from(Span::raw(ph))];
         let area = Rect::new(0, 0, 10, 2);
-        let placements = resolve_placements(&lines, area);
+        let placements = resolve_placements(&lines, area, |_| (2, 1));
         assert_eq!(placements.len(), 2);
         assert_eq!(placements[0].rect.y, 0);
         assert_eq!(placements[1].rect.y, 1);
@@ -182,7 +361,7 @@ mod tests {
         let mut s = placeholder_for_index(5);
         s.push_str(&placeholder_for_index(5));
         let line = Line::from(Span::raw(s));
-        let placements = resolve_placements(&[line], Rect::new(0, 0, 20, 1));
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 20, 1), |_| (2, 1));
         assert_eq!(placements.len(), 2);
         assert_eq!(placements[0].emote_index, 5);
         assert_eq!(placements[1].emote_index, 5);
@@ -197,7 +376,7 @@ mod tests {
         let mut s = placeholder_for_index(1);
         s.push_str(&placeholder_for_index(2));
         let line = Line::from(Span::raw(s));
-        let placements = resolve_placements(&[line], Rect::new(0, 0, 20, 1));
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 20, 1), |_| (2, 1));
         assert_eq!(placements.len(), 2);
         assert_eq!(placements[0].emote_index, 1);
         assert_eq!(placements[1].emote_index, 2);
@@ -212,7 +391,7 @@ mod tests {
         let emoji = "\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}";
         let ph = placeholder_for_index(5);
         let line = Line::from(vec![Span::raw(emoji.to_owned()), Span::raw(ph)]);
-        let placements = resolve_placements(&[line], Rect::new(0, 0, 40, 1));
+        let placements = resolve_placements(&[line], Rect::new(0, 0, 40, 1), |_| (2, 1));
         assert_eq!(placements.len(), 1);
         assert_eq!(
             placements[0].rect.x, 2,
@@ -225,7 +404,7 @@ mod tests {
         let ph = placeholder_for_index(7);
         let lines = vec![Line::from(Span::raw(ph.clone())), Line::from(Span::raw(ph))];
         let area = Rect::new(0, 0, 10, 1); // only 1 row visible
-        let placements = resolve_placements(&lines, area);
+        let placements = resolve_placements(&lines, area, |_| (2, 1));
         assert_eq!(placements.len(), 1);
     }
 }

--- a/src/ui/emote_layout.rs
+++ b/src/ui/emote_layout.rs
@@ -17,6 +17,13 @@ use unicode_width::UnicodeWidthStr;
 /// fallback; chat rendering sizes each emote per [`emote_footprint`].
 pub const EMOTE_COLS: usize = 2;
 
+/// Hard ceilings on an emote's cell footprint, independent of the configured
+/// caps. They bound work driven by user config: a multi-row emote reserves a
+/// blank line per row, so an unsanitised `max_rows` (or a degenerate tiny cell
+/// size) must not be able to balloon the line count.
+pub const MAX_FOOTPRINT_COLS: u16 = 32;
+pub const MAX_FOOTPRINT_ROWS: u16 = 12;
+
 /// Compute the cell footprint `(cols, rows)` for an emote from its native GIF
 /// pixel size, the terminal cell pixel size, and the configured caps.
 ///
@@ -44,8 +51,8 @@ pub fn emote_footprint(
     let nh = f64::from(native_h.max(1));
     let fw = f64::from(font_w.max(1));
     let fh = f64::from(font_h.max(1));
-    let max_cols = max_cols.max(1);
-    let max_rows = max_rows.max(1);
+    let max_cols = max_cols.clamp(1, MAX_FOOTPRINT_COLS);
+    let max_rows = max_rows.clamp(1, MAX_FOOTPRINT_ROWS);
 
     // Fit within the cap box preserving aspect; `min(.., 1.0)` forbids upscaling
     // past the native pixel size.
@@ -132,6 +139,34 @@ pub struct EmotePlacement {
     pub rect: Rect,
 }
 
+/// Reserve vertical space for multi-row emotes: for each wrapped line, find the
+/// tallest emote on it (via `rows_of`) and append that many `- 1` blank lines
+/// after it, so the emote's rect can span downward without overlapping the next
+/// line's text. Lines with only single-row (or no) emotes pass through unchanged.
+#[must_use]
+pub fn reserve_emote_rows(
+    lines: Vec<Line<'_>>,
+    rows_of: impl Fn(u32) -> u16,
+) -> Vec<Line<'_>> {
+    let mut out = Vec::with_capacity(lines.len());
+    for line in lines {
+        let mut max_rows: u16 = 1;
+        for span in &line.spans {
+            for g in span.content.graphemes(true) {
+                if let Some(idx) = decode_placeholder_grapheme(g) {
+                    max_rows = max_rows.max(rows_of(idx).max(1));
+                }
+            }
+        }
+        out.push(line);
+        // Reserve `max_rows - 1` blank continuation rows below the emote line.
+        for _ in 1..max_rows {
+            out.push(Line::default());
+        }
+    }
+    out
+}
+
 /// An emote placeholder run being accumulated across cells on one line.
 struct Run {
     idx: u32,
@@ -159,6 +194,7 @@ pub fn resolve_placements(
     footprint_of: impl Fn(u32) -> (u16, u16),
 ) -> Vec<EmotePlacement> {
     let mut out = Vec::new();
+    let area_bottom = area.y.saturating_add(area.height);
     for (row, line) in lines.iter().enumerate() {
         if row >= area.height as usize {
             break;
@@ -183,7 +219,7 @@ pub fn resolve_placements(
                             r.width += cw;
                         }
                         _ => {
-                            flush_run(&mut run, y, area.x, &mut out);
+                            flush_run(&mut run, y, area.x, area_bottom, &mut out);
                             let (cols, rows) = footprint_of(idx);
                             run = Some(Run {
                                 idx,
@@ -195,19 +231,30 @@ pub fn resolve_placements(
                         }
                     }
                 } else {
-                    flush_run(&mut run, y, area.x, &mut out);
+                    flush_run(&mut run, y, area.x, area_bottom, &mut out);
                 }
                 col += cw;
             }
         }
-        flush_run(&mut run, y, area.x, &mut out);
+        flush_run(&mut run, y, area.x, area_bottom, &mut out);
     }
     out
 }
 
-fn flush_run(run: &mut Option<Run>, y: u16, area_x: u16, out: &mut Vec<EmotePlacement>) {
+fn flush_run(
+    run: &mut Option<Run>,
+    y: u16,
+    area_x: u16,
+    area_bottom: u16,
+    out: &mut Vec<EmotePlacement>,
+) {
     if let Some(r) = run.take() {
         let x = area_x.saturating_add(u16::try_from(r.start).unwrap_or(u16::MAX));
+        // Clamp the height to the rows remaining below `y` in the chat area so a
+        // tall emote on the last visible row never paints over the status/input
+        // bar. `reserve_emote_rows` guarantees the in-area rows below are blank.
+        let avail = area_bottom.saturating_sub(y);
+        let height = r.rows.min(avail).max(1);
         out.push(EmotePlacement {
             emote_index: r.idx,
             // Width is the cells actually occupied (`r.width`), not the target
@@ -215,7 +262,7 @@ fn flush_run(run: &mut Option<Run>, y: u16, area_x: u16, out: &mut Vec<EmotePlac
             // wrapper had to split an over-wide emote across a line edge, this
             // fragment must cover only its own cells — the compositor sizes the
             // image canvas from this rect, so a wider claim would overpaint text.
-            rect: Rect::new(x, y, u16::try_from(r.width).unwrap_or(u16::MAX), r.rows),
+            rect: Rect::new(x, y, u16::try_from(r.width).unwrap_or(u16::MAX), height),
         });
     }
 }
@@ -226,6 +273,16 @@ mod tests {
     use ratatui::text::Span;
 
     // ── emote_footprint tests (font 8×16, caps 8×3 unless noted) ──
+
+    #[test]
+    fn footprint_caps_pathological_config_and_font() {
+        // A huge config cap with a degenerate 1px font must not let an emote's
+        // footprint explode — `reserve_emote_rows` allocates one blank line per
+        // reserved row, so the row count is a hard ceiling, not just the config.
+        let (cols, rows) = emote_footprint(4000, 4000, 1, 1, u16::MAX, u16::MAX);
+        assert!(cols <= MAX_FOOTPRINT_COLS, "cols {cols} exceeds hard cap");
+        assert!(rows <= MAX_FOOTPRINT_ROWS, "rows {rows} exceeds hard cap");
+    }
 
     #[test]
     fn footprint_small_square_stays_two_by_one() {
@@ -281,6 +338,43 @@ mod tests {
         assert_eq!(emote_footprint(40, 18, 16, 32, 8, 3), (3, 1));
     }
 
+    // ── reserve_emote_rows tests ──
+
+    #[test]
+    fn reserve_adds_blank_rows_for_a_tall_emote() {
+        let line = Line::from(Span::raw(placeholder_for_emote(1, 2)));
+        let out = reserve_emote_rows(vec![line], |_| 3);
+        assert_eq!(out.len(), 3, "the line plus 2 reserved blank rows");
+        assert!(!out[0].spans.is_empty(), "row 0 keeps the emote");
+        assert!(out[1].spans.is_empty(), "row 1 is a reserved blank");
+        assert!(out[2].spans.is_empty(), "row 2 is a reserved blank");
+    }
+
+    #[test]
+    fn reserve_leaves_single_row_emote_untouched() {
+        let line = Line::from(Span::raw(placeholder_for_emote(1, 2)));
+        let out = reserve_emote_rows(vec![line], |_| 1);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn reserve_ignores_lines_without_emotes() {
+        let line = Line::from(Span::raw("plain text"));
+        let out = reserve_emote_rows(vec![line], |_| 3);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn reserve_uses_the_tallest_emote_on_a_line() {
+        // idx 1 wants 2 rows, idx 2 wants 3 rows → reserve max(2,3)-1 = 2 blanks.
+        let mut s = placeholder_for_emote(1, 2);
+        s.push_str(&placeholder_for_emote(2, 2));
+        let line = Line::from(Span::raw(s));
+        let out = reserve_emote_rows(vec![line], |idx| if idx == 2 { 3 } else { 2 });
+        assert_eq!(out.len(), 3);
+        assert!(out[1].spans.is_empty() && out[2].spans.is_empty());
+    }
+
     #[test]
     fn resolve_uses_footprint_width_and_splits_adjacent_wide_emotes() {
         // Two adjacent copies of the same 5-col emote must become two 5-wide
@@ -294,6 +388,35 @@ mod tests {
         assert_eq!(placements[1].rect.width, 5);
         assert_eq!(placements[0].rect.x, 0);
         assert_eq!(placements[1].rect.x, 5);
+    }
+
+    #[test]
+    fn resolve_clamps_rect_height_to_area_bottom() {
+        // Area is 2 rows tall; a 3-row emote on the last row must clamp to the one
+        // remaining row so it never paints below the chat area (into status/input).
+        let blank = Line::default();
+        let emote = Line::from(Span::raw(placeholder_for_emote(1, 2)));
+        let placements =
+            resolve_placements(&[blank, emote], Rect::new(0, 0, 40, 2), |_| (2, 3));
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].rect.y, 1);
+        assert_eq!(
+            placements[0].rect.height, 1,
+            "clamped to the single remaining row"
+        );
+    }
+
+    #[test]
+    fn resolve_keeps_full_height_when_rows_fit() {
+        let emote = Line::from(Span::raw(placeholder_for_emote(1, 2)));
+        let placements = resolve_placements(
+            &[emote, Line::default(), Line::default()],
+            Rect::new(0, 0, 40, 5),
+            |_| (2, 3),
+        );
+        assert_eq!(placements.len(), 1);
+        assert_eq!(placements[0].rect.y, 0);
+        assert_eq!(placements[0].rect.height, 3);
     }
 
     #[test]

--- a/src/ui/emote_picker.rs
+++ b/src/ui/emote_picker.rs
@@ -144,7 +144,10 @@ pub fn render(frame: &mut Frame, area: Rect, app: &mut App) {
         // cell is never blank-but-clickable.
         if graphical && cell_w > emote_w {
             let img_rect = Rect::new(x, y, emote_w, 1);
-            if let Some(proto) = app.emote_animator.thumbnail(&app.picker, reg_idx, bg_rgb) {
+            if let Some(proto) =
+                app.emote_animator
+                    .thumbnail(&app.picker, reg_idx, bg_rgb, emote_w, 1)
+            {
                 frame.render_stateful_widget(
                     ratatui_image::StatefulImage::default(),
                     img_rect,

--- a/src/ui/message_line.rs
+++ b/src/ui/message_line.rs
@@ -9,24 +9,25 @@ use ratatui::text::Line;
 
 /// Render a single message into a themed ratatui Line.
 ///
-/// When `graphical` is true (emotes enabled, render=Graphical, terminal supports
-/// graphics), known `:name:` tokens in the message body are rewritten to
-/// fixed-width placeholders so the wrapper reserves cells for the inline image;
-/// otherwise the literal `:name:` text is kept.
+/// When `emote_sizing` is `Some` (emotes enabled, render=Graphical, terminal
+/// supports graphics), known `:name:` tokens in the message body are rewritten
+/// to placeholders sized per the emote's cell footprint so the wrapper reserves
+/// the right number of cells for the inline image; otherwise the literal
+/// `:name:` text is kept.
 pub fn render_message(
     msg: &Message,
     is_own: bool,
     theme: &crate::theme::ThemeFile,
     config: &AppConfig,
     nick_fg_override: Option<Color>,
-    graphical: bool,
+    emote_sizing: Option<crate::ui::emote_layout::EmoteSizing>,
 ) -> Line<'static> {
     let abstracts = &theme.abstracts;
 
     // MentionLog: pre-formatted line — render text as-is, no timestamp/nick column.
     // Emotes are still rewritten so mention rows match the channel/web rendering.
     if msg.message_type == MessageType::MentionLog {
-        let body = emotify_message_text(&msg.text, graphical);
+        let body = emotify_message_text(&msg.text, emote_sizing);
         let spans = parse_format_string(&body, &[]);
         return styled_spans_to_line(&spans);
     }
@@ -48,7 +49,7 @@ pub fn render_message(
     let msg_spans = if msg.message_type == MessageType::Event {
         render_event(msg, theme)
     } else {
-        render_chat_message(msg, is_own, theme, config, nick_fg_override, graphical)
+        render_chat_message(msg, is_own, theme, config, nick_fg_override, emote_sizing)
     };
 
     // 3. Combine: timestamp + space + message
@@ -94,7 +95,7 @@ fn render_chat_message(
     theme: &crate::theme::ThemeFile,
     config: &AppConfig,
     nick_fg_override: Option<Color>,
-    graphical: bool,
+    emote_sizing: Option<crate::ui::emote_layout::EmoteSizing>,
 ) -> Vec<StyledSpan> {
     let abstracts = &theme.abstracts;
     let messages = &theme.formats.messages;
@@ -148,7 +149,7 @@ fn render_chat_message(
         .unwrap_or_else(|| "$0 $1".to_string());
     let resolved = resolve_abstractions(&msg_format, abstracts, 0);
     // params: $0=displayNick, $1=text, $2=paddedNickMode
-    let body = emotify_message_text(&msg.text, graphical);
+    let body = emotify_message_text(&msg.text, emote_sizing);
     let mut spans = parse_format_string(&resolved, &[&display_nick, &body, &padded_nick_mode]);
 
     // Apply nick color override: recolor spans containing the nick text.
@@ -167,17 +168,25 @@ fn render_chat_message(
     spans
 }
 
-/// Replace known `:name:` tokens with fixed-width PUA placeholders so the wrapper
-/// reserves cells for the inline image. No-op when `graphical` is false or the
-/// text contains no emote. The emote's placeholder index is its position in
-/// `emotes::names()` (binary-searchable, matching the animator's lookup).
+/// Replace known `:name:` tokens with PUA placeholders so the wrapper reserves
+/// cells for the inline image. Each emote's placeholder width is its cell
+/// footprint (`sizing.footprint().0`) so wide GIFs reserve more columns. No-op
+/// when `sizing` is `None` (text mode) or the text contains no emote. The emote's
+/// placeholder index is its position in `emotes::names()` (binary-searchable,
+/// matching the animator's lookup).
 #[must_use]
-fn emotify_message_text(text: &str, graphical: bool) -> String {
+fn emotify_message_text(
+    text: &str,
+    sizing: Option<crate::ui::emote_layout::EmoteSizing>,
+) -> String {
     use crate::emotes;
     use crate::emotes::parse::Segment;
-    use crate::ui::emote_layout::placeholder_for_index;
+    use crate::ui::emote_layout::placeholder_for_emote;
 
-    if !graphical || !text.contains(':') {
+    let Some(sizing) = sizing else {
+        return text.to_owned();
+    };
+    if !text.contains(':') {
         return text.to_owned();
     }
     let segs = emotes::parse::tokenize(text);
@@ -191,7 +200,8 @@ fn emotify_message_text(text: &str, graphical: bool) -> String {
             Segment::Emote(name) => {
                 // Accept either language: resolve PL stem or EN alias to the index.
                 if let Some(idx) = emotes::resolve(&name) {
-                    out.push_str(&placeholder_for_index(idx));
+                    let (cols, _rows) = sizing.footprint(idx);
+                    out.push_str(&placeholder_for_emote(idx, cols));
                 } else {
                     out.push(':');
                     out.push_str(&name);
@@ -206,51 +216,86 @@ fn emotify_message_text(text: &str, graphical: bool) -> String {
 #[cfg(test)]
 mod emote_tests {
     use super::emotify_message_text;
-    use crate::ui::emote_layout::{EMOTE_COLS, decode_placeholder_index};
+    use crate::ui::emote_layout::{EmoteSizing, decode_placeholder_index};
+
+    /// A representative cell size (8×16) with the conservative one-row cap.
+    fn sizing() -> EmoteSizing {
+        EmoteSizing {
+            font_w: 8,
+            font_h: 16,
+            max_cols: 8,
+            max_rows: 1,
+        }
+    }
+
+    fn placeholder_count(s: &str) -> usize {
+        s.chars()
+            .filter(|c| decode_placeholder_index(*c).is_some())
+            .count()
+    }
 
     #[test]
     fn english_alias_becomes_placeholder() {
-        let out = emotify_message_text("hi :smile: x", true);
-        let placeholders = out
-            .chars()
-            .filter(|c| decode_placeholder_index(*c).is_some())
-            .count();
+        let sizing = sizing();
+        let idx = crate::emotes::resolve("smile").expect("smile resolves");
+        let expected = usize::from(sizing.footprint(idx).0);
+        let out = emotify_message_text("hi :smile: x", Some(sizing));
         assert_eq!(
-            placeholders, EMOTE_COLS,
-            ":smile: must become a placeholder"
+            placeholder_count(&out),
+            expected,
+            ":smile: must become a footprint-width placeholder run"
         );
         assert!(!out.contains(":smile:"));
     }
 
     #[test]
     fn known_token_becomes_placeholder_when_graphical() {
-        let out = emotify_message_text("hi :usmiech: x", true);
-        let placeholder_chars = out
-            .chars()
-            .filter(|c| decode_placeholder_index(*c).is_some())
-            .count();
-        assert_eq!(placeholder_chars, EMOTE_COLS);
+        let sizing = sizing();
+        let idx = crate::emotes::resolve("usmiech").expect("usmiech resolves");
+        let expected = usize::from(sizing.footprint(idx).0);
+        let out = emotify_message_text("hi :usmiech: x", Some(sizing));
+        assert_eq!(placeholder_count(&out), expected);
         assert!(!out.contains(":usmiech:"));
         assert!(out.starts_with("hi "));
         assert!(out.ends_with(" x"));
     }
 
     #[test]
+    fn wide_emote_reserves_more_columns_than_a_square_one() {
+        // A wide GIF (a banner like 40×18) must reserve strictly more cells than a
+        // small square one (:smile:/15×15) — the core of "size to the original".
+        let sizing = sizing();
+        let square = crate::emotes::resolve("smile").expect("smile");
+        let names_len = u32::try_from(crate::emotes::names().len()).unwrap_or(u32::MAX);
+        let wide = (0..names_len)
+            .find(|&i| {
+                crate::emotes::native_size(i).is_some_and(|(w, h)| w >= h.saturating_mul(2))
+            })
+            .expect("the curated set has at least one wide emote");
+        let square_cols = usize::from(sizing.footprint(square).0);
+        let wide_cols = usize::from(sizing.footprint(wide).0);
+        assert!(
+            wide_cols > square_cols,
+            "wide emote ({wide_cols} cols) must reserve more than square ({square_cols} cols)"
+        );
+    }
+
+    #[test]
     fn unchanged_when_not_graphical() {
         assert_eq!(
-            emotify_message_text("hi :usmiech: x", false),
+            emotify_message_text("hi :usmiech: x", None),
             "hi :usmiech: x"
         );
     }
 
     #[test]
     fn unknown_token_unchanged() {
-        assert_eq!(emotify_message_text(":nope: :)", true), ":nope: :)");
+        assert_eq!(emotify_message_text(":nope: :)", Some(sizing())), ":nope: :)");
     }
 
     #[test]
     fn no_colon_fast_path() {
-        assert_eq!(emotify_message_text("plain text", true), "plain text");
+        assert_eq!(emotify_message_text("plain text", Some(sizing())), "plain text");
     }
 }
 
@@ -284,7 +329,7 @@ mod tests {
         let msg = test_message("me", "hello world", MessageType::Message);
         let theme = default_theme();
         let config = default_config();
-        let line = render_message(&msg, true, &theme, &config, None, false);
+        let line = render_message(&msg, true, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("me"));
         assert!(text.contains("hello world"));
@@ -295,7 +340,7 @@ mod tests {
         let msg = test_message("bob", "hi there", MessageType::Message);
         let theme = default_theme();
         let config = default_config();
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("bob"));
         assert!(text.contains("hi there"));
@@ -309,7 +354,7 @@ mod tests {
         let mut config = default_config();
         config.display.nick_truncation = true;
         config.display.nick_max_length = 4;
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("Ñóçk"));
         assert!(text.contains("hola mundo"));
@@ -323,7 +368,7 @@ mod tests {
         let mut config = default_config();
         config.display.nick_truncation = true;
         config.display.nick_max_length = 4;
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         // Should be truncated to first 3 chars + '+': "Ñóç+"
         assert!(text.contains("Ñóç+"));
@@ -339,7 +384,7 @@ mod tests {
         let mut config = default_config();
         config.display.nick_truncation = true;
         config.display.nick_max_length = 7;
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("verylo+"));
         assert!(!text.contains("verylon"));
@@ -355,7 +400,7 @@ mod tests {
         let mut config = default_config();
         config.display.nick_truncation = true;
         config.display.nick_max_length = 8;
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         // Nick should be "verylo+" (7 chars), not "verylon+" (8 chars)
         assert!(text.contains("verylo+"), "expected 'verylo+' in: {text}");
@@ -366,7 +411,7 @@ mod tests {
 
         // Without mode prefix, same nick gets full budget: "verylon+" (8 chars)
         let msg2 = test_message("verylongnick", "test", MessageType::Message);
-        let line2 = render_message(&msg2, false, &theme, &config, None, false);
+        let line2 = render_message(&msg2, false, &theme, &config, None, None);
         let text2: String = line2.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(
             text2.contains("verylon+"),
@@ -392,7 +437,7 @@ mod tests {
         };
         let theme = default_theme();
         let config = default_config();
-        let line = render_message(&msg, false, &theme, &config, None, false);
+        let line = render_message(&msg, false, &theme, &config, None, None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("system message"));
     }
@@ -412,7 +457,7 @@ mod tests {
             .insert("pubmsg".into(), "{msgnick $2 {pubnick $0}}$1".into());
         let config = default_config();
         let override_color = Color::Rgb(255, 0, 0);
-        let line = render_message(&msg, false, &theme, &config, Some(override_color), false);
+        let line = render_message(&msg, false, &theme, &config, Some(override_color), None);
         let text: String = line.spans.iter().map(|s| s.content.to_string()).collect();
         assert!(text.contains("alice"));
         // Check that at least one span has the override color


### PR DESCRIPTION
## Problem

Two issues with inline GG7 emotes in the TUI:

1. **Wide GIFs rendered tiny.** Every `:name:` emote was forced into a fixed 2-cell × 1-row box (`EMOTE_COLS = 2`). Since most GG7 assets are **wide and short** (e.g. 40×18, 35×18, 50×20; max 64×46), they were aspect-fit into ~16×7px — a tiny squished strip. The original GIF size was ignored entirely.
2. **Emotes broke when the terminal font size changed.** `picker.font_size()` was detected once at startup (`from_query_stdio`) and only refreshed on shim reattach. `Event::Resize` never refreshed it, and the animator cache isn't keyed by cell size — so after a live font zoom, emotes rendered at the old scale, correct only near the launch size.

## What changed

Three commits, each reviewed and TDD'd:

1. **Rescale on font change** — on `Event::Resize`, re-derive the cell pixel size from `crossterm::terminal::window_size()` (a `TIOCGWINSZ` ioctl — *not* a stdio re-query, which would race the crossterm event stream), rebuild the `Picker` when it changed, and clear the emote protocol cache.
2. **Size to native GIF width** — `emotes::native_size` reads the GIF header (no decode); `emote_footprint` maps native px → `(cols, rows)` preserving aspect, **never upscaling past the original**, capped by config. Threaded end-to-end via a per-frame `EmoteSizing` (placeholder width, `resolve_placements`, render canvas, cache key). Small square emotes keep their ~2×1 size; wide ones span proportionally more columns.
3. **Multi-row tall GIFs** — `chat_view` reserves blank continuation rows below any line carrying a multi-row emote (`reserve_emote_rows`) so the emote grows downward without overlapping the next line; the rect height is clamped to the chat-area bottom so it never paints over the status/input bar. Hard `MAX_FOOTPRINT_COLS/ROWS` ceilings bound config-driven allocation.

New config: `[emotes] max_cols` (default 8), `max_rows` (default 3); set `max_rows = 1` to keep emotes strictly one row tall. Backward compatible (serde defaults; old configs covered by a test).

## Design notes

- Given the asset sizes (mostly ≤20px tall), only genuinely tall GIFs gain extra rows — most emotes stay one row, so chat layout is barely affected while large GIFs finally render large.
- The v0.8.4 OOM render-budget bound still holds: `reserve_emote_rows` runs *before* the `visual_lines.len() > needed` break, so reserved blanks count toward the budget (expansion makes the loop terminate sooner, not later).
- The web UI emote path is unaffected (it sizes via CSS, separate from the TUI cell footprint).

## Testing

- `make clippy` — 0 warnings (pedantic + nursery + perf/redundant_clone deny).
- `make test` — 1297 passing (+19 new: footprint math, native_size vs decoded frames, font-size derivation, cache clear, variable-width/height placement, multi-row reservation, bottom-edge clamp, pathological-config ceiling, config round-trip).
- ⚠️ **Not visually verified** in a graphics terminal (headless environment). Geometry is covered by unit tests; please eyeball the actual rendering (Kitty/iTerm2/Sixel) — especially wide and tall emotes, font zoom in/out, and an emote at the very bottom of the chat.

Version bump in `Cargo.toml` intentionally left for the maintainer's release step (changelog entry added under v1.5.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Size inline emotes to native GIF dimensions and rescale on terminal font change
> - Emotes now compute a `(cols, rows)` footprint from native GIF pixel dimensions, the terminal's font cell size, and configurable `max_cols`/`max_rows` caps (defaulting to 8×3) in `EmotesConfig`.
> - `emote_footprint` in [emote_layout.rs](https://github.com/outragedevs/repartee/pull/21/files#diff-e8cd18467041cc00d5929c2f22407c37ccb8cfda76a0e3b4d59cca19f421f3d4) derives the footprint preserving aspect ratio without upscaling; `reserve_emote_rows` inserts blank lines below multi-row emotes to prevent overlap with following chat text.
> - On `Event::Resize`, `App.refresh_emote_font_size` recomputes the picker's font size from the terminal window pixel dimensions and clears the `EmoteAnimator` cache when the cell size changes.
> - `render_frame_on_bg` now scales rendered bitmaps to the exact `cols×rows` cell rectangle instead of a fixed `EMOTE_COLS` constant.
> - Risk: chat layout changes — messages with tall emotes now reserve blank rows, which may shift visible message history on resize or font-size change.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 20af352.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->