### PR TITLE
fix(e2e): align RPE2E companion scripts with the client E2E gate (F1+F2)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
@@ -1,0 +1,171 @@
+# RPE2E companion scripts — align with the Rust E2E gate
+
+**Date:** 2026-07-09
+**Branch:** `fix/rpe2e-companion-scripts`
+**Scope:** `scripts/weechat/rpe2e.py`, `scripts/irssi/rpe2e.pl`
+
+## Goal
+
+Make the WeeChat (Python) and irssi (Perl) companion scripts enforce the same
+end-to-end semantics as the Rust `repartee` client. The overriding rule is
+**fail-closed**: if E2E is enabled for a conversation, the scripts must NEVER put
+plaintext on the wire and NEVER render raw ciphertext; every refusal must be
+visible to the user; cleartext is allowed only after E2E is explicitly disabled.
+
+Reference implementation to mirror (do not diverge from it):
+
+- `src/app/e2e_gate.rs` — `e2e_encrypt_or_passthrough`, `e2e_send_plan_for_target`,
+  the `E2eRefusal` variants, the channel-only single-line bot bypass.
+- `src/e2e/manager.rs` — `encrypt_outgoing_ctcp` (frame-aware ACTION split).
+- `src/e2e/chunker.rs` — `MAX_PLAINTEXT_PER_CHUNK` (180), `MAX_CHUNKS` (16),
+  stateless chunks.
+- `src/e2e/mod.rs` — `context_key`, `is_channel_target`, `scoped_context`
+  (`"{network}\x1F{wire}"`), `wire_context`.
+- `docs/rpe2e-dm-addendum.md` — recipient-keyed DM context.
+
+## Findings being fixed
+
+### F1 [HIGH] — outgoing `/me`, `/msg`, `/say` leak plaintext (both scripts)
+
+The only outbound gate bails on any `/`-command:
+
+- weechat `rpe2e.py` `hook_input_text_for_buffer`: `if text.startswith("/"): return text`.
+  Registered hooks are only `irc_in2_privmsg`, `input_text_for_buffer`,
+  `irc_in2_notice` — there is **no outgoing PRIVMSG hook**.
+- irssi `rpe2e.pl` `signal_send_text`: `return if ... $data =~ m{^/}`. Only the
+  high-level `send text` signal is hooked.
+
+So `/me` (ACTION), `/msg`, `/say`, `/amsg`, and any other command that emits a
+PRIVMSG reach the wire as plaintext even when the conversation has E2E enabled.
+
+### F2 [MED] — irssi mis-renders incoming encrypted ACTIONs
+
+irssi decrypts on `message public` / `message private`, which fire **after**
+irssi has spliced out CTCP/ACTION. An encrypted ACTION arrives on the wire as
+`+RPE2E01…` (no `\x01`), so it is treated as a normal message, decrypted to
+`\x01ACTION…\x01`, and re-emitted with `signal_continue` **past** the CTCP
+splitter → renders with raw control characters. WeeChat decrypts in the raw-line
+modifier `irc_in2_privmsg`, before CTCP parsing, so it is already correct.
+
+### F3 [LOW-MED] — no per-network context scoping (both scripts)
+
+Storage keys on the bare wire context (`#chan` / `@handle`) with no network
+column. One process on two networks shares `#rust`'s config and outgoing key
+across both networks — a confidentiality-boundary violation. Rust scopes
+storage as `scoped_context(network, wire) = "{network}\x1F{wire}"` while every
+byte that leaves the process (AAD, handshake `c=`) uses the bare `wire_context`.
+
+## Design
+
+### Architecture principle
+
+Mirror Rust's single fail-closed chokepoint. In the Rust client every send path
+routes through `e2e_encrypt_or_passthrough`. The scripts get the structural
+equivalent: **one low-level outgoing chokepoint per client** that every PRIVMSG
+passes through, regardless of which command produced it.
+
+- weechat: `weechat.hook_modifier("irc_out1_privmsg", …)`.
+- irssi: `Irssi::signal_add_first("server sending command", …)`.
+
+At this layer `/me`, `/msg`, `/say`, `/amsg`, and plain input all appear as a
+raw `PRIVMSG target :…` line. The existing input-text hooks stay in place for
+plain-line local echo; their already-encrypted `+RPE2E01` output passes through
+the chokepoint unchanged. The chokepoint is the **authoritative** gate
+(defense-in-depth): any plaintext PRIVMSG to an E2E target that slips past the
+input hook is still caught.
+
+### F1 — the outgoing gate (mirror of `e2e_encrypt_or_passthrough`)
+
+Order of checks, per PRIVMSG line reaching the chokepoint:
+
+1. **Re-entrancy guard.** If the message body already starts with `+RPE2E01`,
+   pass through unchanged. This covers both the input-hook's own encrypted
+   output and the script's `_send_raw_privmsg` re-emissions.
+2. **Classify** the target as channel vs DM by the `#&!+` prefix
+   (`is_channel_target` / `context_key`).
+3. **Bot-command bypass.** Prefix `.`/`!`, **channel-only**, **single-line**
+   (no embedded `\n`), emit a **visible** `[E2E] … CLEARTEXT` warning when E2E
+   is enabled on that channel (mirror of `warn_e2e_bot_bypass`). DMs never
+   bypass. A multi-line body never bypasses.
+4. **Resolve the storage context.**
+   - Channel: `scoped_context(network, channel)`.
+   - DM: resolve the peer handle (live/cached, same resolution `/e2e on` used),
+     then `scoped_context(network, "@" + handle)`.
+5. **Enabled check + fail-closed refusals**, mirroring the `E2eRefusal` variants
+   with a distinct, visible `[E2E]` line each:
+   - DM handle unresolved but an enabled config exists → refuse (`NoPeerHandle`
+     analogue: "cannot encrypt PM without peer handle — wait for a message from
+     them first").
+   - keyring/DB read error → refuse (`KeyringRead`: "message NOT sent").
+   - encryption itself fails → refuse (`EncryptFailed`: "message NOT sent as
+     plaintext").
+   - not enabled and no E2E state → pass through as plaintext.
+6. **CTCP ACTION framing.** If the body is a `\x01ACTION …\x01` frame, use the
+   frame-aware splitter (mirror `encrypt_outgoing_ctcp`): a frame that fits one
+   chunk encrypts as-is; a longer ACTION splits into independent, individually
+   wrapped `\x01ACTION piece\x01` frames with per-piece budget
+   `MAX_PLAINTEXT_PER_CHUNK - len("\x01ACTION ") - 1`. Never fragment the CTCP
+   envelope across bare chunks.
+7. Emit N `+RPE2E01` PRIVMSG lines (drop/replace the original), draining any
+   lazy-rotation REKEY NOTICEs exactly as the input path already does.
+
+**Known limitation (accepted).** For command paths the client core echoes the
+plaintext locally *before* the chokepoint decides. On a refusal the user sees
+their line locally although nothing reached the wire. Mitigation: a prominent
+`[E2E] message NOT sent …` line. Fail-closed is preserved — zero plaintext on
+the wire. The plain-input path is unaffected (it echoes only after encrypting).
+
+**NOTICEs are never encrypted.** The chokepoint is PRIVMSG-only; KEYREQ/KEYRSP/
+REKEY continue to travel as plaintext CTCP NOTICEs.
+
+### F2 — decrypt irssi before the CTCP split
+
+Move irssi decryption off `message public`/`message private` onto the raw
+incoming line signal **`server incoming`** (the analogue of weechat's
+`irc_in2_privmsg`). Decrypting there rewrites the raw line so the recovered
+`\x01ACTION…\x01` re-enters irssi's normal pipeline **before** the CTCP splitter
+and renders as a proper action. Channel/DM/CTCP handling is otherwise unchanged.
+Non-RPE2E lines pass through untouched.
+
+### F3 — per-network scoping (mirror `scoped_context` / `wire_context`)
+
+- **Storage key** = `scoped_context(network, wire)` = `"{network}\x1F{wire}"`,
+  separator `U+001F`. Network label: weechat `localvar_server`, irssi
+  `$server->{tag}`.
+- **Interop-critical:** `build_aad` and the handshake `c=` field ALWAYS use the
+  bare `wire_context`, never the scoped key — byte-identical to Rust. The scoped
+  form exists only in local storage. Inbound handshake `c=` is re-scoped to the
+  live network before storage; outbound `c=` carries the bare wire.
+- weechat: add a `network` column to `channels`, `incoming`, `outgoing`,
+  `outgoing_recipients`, `pending`, `pending_inbound` (and the primary keys);
+  migrate existing rows to a best-effort/legacy-unscoped form that still
+  resolves (mirroring Rust's legacy fallback so a single-network user is not
+  locked out).
+- irssi: hash keys become `"{network}\x1F{wire}"`; the JSON keyring gains the
+  same scoping with a legacy fallback for pre-scoping keys.
+
+Legacy fallback rule (mirror Rust): a scoped lookup that misses falls back to
+the unscoped row **only when it cannot cause cross-network leakage** — i.e. keep
+the fallback for reads so an existing single-network user keeps working, but a
+send that resolves a handle only via an unscoped legacy row must refuse rather
+than send plaintext under a possibly-wrong network (mirror the multi-network
+upgrade guard). This is the sharp edge; it gets dedicated review.
+
+## Testing
+
+Tooling present locally: `python3`, `perl` (+ `Crypt::NaCl::Sodium`), `weechat`,
+`irssi`. A full two-peer handshake harness is out of scope; verification is:
+
+- weechat: `python3 -m py_compile scripts/weechat/rpe2e.py`.
+- irssi: `perl -I<stub> -c scripts/irssi/rpe2e.pl` (stub `Irssi.pm` for the
+  runtime-only module).
+- Fidelity review against the Rust reference for each finding.
+- Where feasible, a script-load smoke test.
+
+## Phasing (separate commits, per-phase code review)
+
+1. **F1 weechat** — `irc_out1_privmsg` gate + CTCP ACTION splitter.
+2. **F1 irssi** — `server sending command` gate + CTCP ACTION splitter.
+3. **F2 irssi** — move decryption to `server incoming`.
+4. **F3 both** — per-network scoping (interop-critical, isolated, own review).
+5. PR to `outrage/main`. No merge without approval.

--- a/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
@@ -181,3 +181,28 @@ Tooling present locally: `python3`, `perl` (+ `Crypt::NaCl::Sodium`), `weechat`,
    both worse than the LOW-MED issue it fixes. Design + full change-surface map
    captured in `2026-07-09-rpe2e-f3-network-scoping-followup.md`.
 5. **PR to `outrage/main` with F1+F2** (this branch). No merge without approval.
+6. **Post-PR review round (P1/P2)** — resolved 2026-07-09:
+   - **P1 (irssi gate "disabled" via wrong signal handling): REFUTED against
+     irssi source.** `server outgoing modify` passes the line as a
+     `GString *` (`docs/signals.txt:154`); irssi's Perl glue marshals
+     `gstring` args as a SCALAR REF and writes changes back
+     (`perl-signals.c`), and the emitter (`irc_server_send_and_redirect`,
+     `irc-servers.c`) skips the socket write entirely when the string is
+     blanked (`if (str->len)`). Scalar-ref mutation is therefore the correct
+     mechanism, not `signal_continue` (that idiom is for by-value `char *`
+     signals like `send text`). Real adjacent gap found while verifying: the
+     signal only exists since **irssi 1.4.1** (2022-06-12) — on older irssi
+     the hook binds to a never-emitted name and the gate silently vanishes.
+     Fixed with a load-time version check that refuses to load (fail-closed).
+   - **P2 (ambiguous STATUSMSG stripping): CONFIRMED, fixed stronger than
+     suggested.** `+`/`&` are both STATUSMSG prefixes and RFC 2811 channel
+     prefixes, so `+#chan` has two readings. Blind stripping leaked one way;
+     the suggested "don't strip channel-prefix chars" leaks the other way
+     (`/msg +#secret` as a voice-STATUSMSG on a `CHANTYPES=#` server).
+     Fix: `_channel_readings` returns every reading; outbound encrypts under
+     the single enabled reading (wrong-reading recipients see ciphertext,
+     never plaintext), refuses when BOTH readings are enabled, and fails
+     closed on any read error; inbound prefers the reading holding a trusted
+     session (a wrong pick just fails AEAD). ISUPPORT-based resolution was
+     rejected: irssi's Perl API exposes no ISUPPORT accessor, and ISUPPORT
+     alone still cannot resolve an overlap server.

--- a/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-companion-scripts-design.md
@@ -164,8 +164,20 @@ Tooling present locally: `python3`, `perl` (+ `Crypt::NaCl::Sodium`), `weechat`,
 
 ## Phasing (separate commits, per-phase code review)
 
-1. **F1 weechat** — `irc_out1_privmsg` gate + CTCP ACTION splitter.
-2. **F1 irssi** — `server sending command` gate + CTCP ACTION splitter.
-3. **F2 irssi** — move decryption to `server incoming`.
-4. **F3 both** — per-network scoping (interop-critical, isolated, own review).
-5. PR to `outrage/main`. No merge without approval.
+1. **F1 weechat** — `irc_out1_privmsg` gate + CTCP ACTION splitter. ✅ done
+   (+ a pre-existing `db_conn` commit fix without which the gate could never
+   see an enabled config; + 6 review findings fixed).
+2. **F1 irssi** — `server sending command` gate + CTCP ACTION splitter. ✅ done
+   (+ 7 review findings fixed, incl. removing `signal_send_text` so the gate is
+   the single chokepoint; live+cache DM handle resolution; STATUSMSG handling).
+3. **F2 irssi** — decrypt on `event privmsg` (pre-CTCP-split). ✅ done.
+   Consistency sweep applied the STATUSMSG + incoming non-ACTION-CTCP-drop +
+   refusal-wording findings to weechat too.
+4. **F3 both** — per-network scoping. **Deferred to a dedicated follow-up**
+   (decision 2026-07-09): it is interop-critical and has a real migration
+   sharp-edge the current scripts are not equipped for (no "configured
+   networks" list like the Rust client's `legacy_adoption_allowed`). Doing it
+   hastily risks a fail-open downgrade-after-upgrade or a cross-network leak —
+   both worse than the LOW-MED issue it fixes. Design + full change-surface map
+   captured in `2026-07-09-rpe2e-f3-network-scoping-followup.md`.
+5. **PR to `outrage/main` with F1+F2** (this branch). No merge without approval.

--- a/docs/superpowers/specs/2026-07-09-rpe2e-f3-network-scoping-followup.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-f3-network-scoping-followup.md
@@ -1,0 +1,160 @@
+# RPE2E companion scripts — F3: per-network context scoping (follow-up)
+
+**Status:** deferred from the F1/F2 branch `fix/rpe2e-companion-scripts`
+(decision 2026-07-09). This doc captures the design and the full change-surface
+map so the follow-up can be done as one focused, interop-tested change.
+
+## The finding (F3, LOW-MED)
+
+Both scripts use a single global keyring (one SQLite DB / one JSON `$kr`) shared
+across all networks, keyed by the **bare** wire context (`#rust`, `@ident@host`).
+One process on two networks therefore shares `#rust`'s config and outgoing key
+across both — a confidentiality-boundary violation.
+
+## Target model (mirror Rust exactly)
+
+- **Storage key** = `scoped_context(network, wire)` = `"{network}\x1F{wire}"`
+  (U+001F). Encoded as a single string — no schema change; the SQLite `channel`
+  column / JSON hash key just holds the scoped string.
+- **On the wire, BARE always:** `build_aad`, the KEYREQ/KEYRSP/REKEY `c=` field,
+  the signature payloads (`KEYREQ:`/`KEYRSP:`/`REKEY:` …), and the HKDF
+  `RPE2E01-WRAP:` / `RPE2E01-REKEY:` info strings all use `wire_context(ctx)`
+  (the part after `\x1F`, or the whole string if unscoped). Interop with the
+  Rust client and between the two scripts must stay byte-identical.
+- **Inbound handshake:** verify the signature against the received **bare** `c=`,
+  then store under `scoped_context(local_network, c=)`. Mirrors
+  `src/irc/events.rs:4499-4507` (scope `req.channel` for storage) while the
+  manager verifies/derives against `wire_context`.
+
+## The migration sharp-edge (why this is not a mechanical change)
+
+Existing users have **bare** rows (`#rust`, `@handle`). After the upgrade the
+gate looks up `scoped(net, #rust)` and misses. Two wrong ways out:
+
+- **Fail-open:** treat the miss as "not enabled" → silently downgrade a
+  previously-E2E conversation to **plaintext**.
+- **Cross-network leak:** a naive bare-row fallback lets network A's `#rust`
+  encrypt under network B's `#rust` config/key — reintroducing the F3 bug.
+
+Rust avoids both with a **configured-networks list**: it only falls back to /
+adopts a legacy bare row when a **single** network is configured
+(`legacy_adoption_allowed`), and refuses (fail-closed) otherwise. The scripts
+have no such list yet and must add one:
+
+- weechat: enumerate IRC servers via the `irc_server` infolist.
+- irssi: `Irssi::servers()`.
+
+Rule (mirror Rust): scoped lookup first; on miss, consult the bare row **only
+when exactly one network is configured** (then adopt it — rewrite to scoped and
+drop the bare row). With >1 network, a send that resolves only via a bare row
+must **refuse**, not send plaintext. Enumerate the 0/1/2+ configured-network
+cases explicitly (see the project memory `e2e-fail-closed-gate-rule`).
+
+## Hazards found in the surface map (MUST address)
+
+1. **weechat already uses `\x1F`** inside `_pending_key`
+   (`_pending_key(channel, handle) → f"{channel}\x1f{handle}"`, `rpe2e.py:506`).
+   Scoping with the same separator collides. Scope the **outer** key and keep
+   the composite: `"{network}\x1F{channel}\x1F{handle}"`, or pick a distinct
+   separator for one layer. irssi uses `|` for the composite (`"$channel|$handle"`),
+   so it only needs the outer `\x1F` — but be consistent.
+2. **irssi has NO network-label source** anywhere in the file. Add
+   `$server->{tag}` (or `->{chatnet}`). `$server` is threaded to every gate /
+   decrypt / notice site EXCEPT the handshake handlers `handle_keyreq` /
+   `handle_keyrsp` / `handle_rekey` (`rpe2e.pl:734/803/880`), which currently
+   take `($kr, $sender_handle, $nick, $body)` — thread the network label in.
+3. **Aggregate/scan sites span networks** and need scope-filtering, not just
+   key-rewriting: `/e2e status` counts (`rpe2e.py:2364-2365`, `rpe2e.pl:1075-1076`),
+   `/e2e list`, and the `handle LIKE`/handle-pattern deletes in `/e2e reverify`
+   and `/e2e forget -all` (`rpe2e.py:2609/2637/2612/2639`,
+   `rpe2e.pl:1256-1259/1313-1315/1331-1333`) — decide per-command whether they
+   should be per-network or all-network.
+4. **Handshake handlers store the received `c=` verbatim** — the single most
+   important set of sites. Each needs BOTH forms: bare `ctx` for
+   verify + `c=`/sig/KDF (echoed back on the wire), and
+   `scope(local_network, ctx)` for every storage write.
+5. **`_config_enabled` / gate context derivation** (`rpe2e.py:1827`, the
+   `_e2e_gate_wire` `context =` lines; `rpe2e.pl` `_gate_decide` `$ctx =` lines)
+   must scope, and the network label must be threaded from the `server` hook
+   param / `$server->{tag}`.
+6. **export/import** (`/e2e export`/`import`) round-trips the raw keys — decide
+   whether exported keys are scoped or bare (bare is more portable across
+   networks; scoped preserves the boundary). Rust exports/imports its stored
+   form; match whatever keeps cross-tool import working.
+
+## Full change-surface map
+
+See the appendix below (generated 2026-07-09). Each site is tagged
+`[STORAGE-KEY | AAD | WIRE-c= | SIG | NETWORK-LABEL]`. STORAGE-KEY sites get
+scoped; AAD/WIRE-c=/SIG/KDF sites stay bare.
+
+### weechat (`scripts/weechat/rpe2e.py`)
+
+- **Helpers producing the key:** `context_key` (505-512), `_ctx_for_target`
+  (839-846), `_ctx_for_command`/`_ctx_or_error` (848-883), `_e2e_gate_wire`
+  context lines (~1971-1992), `_pending_key` (505-506, already `\x1F`).
+- **`channels` (PK=channel):** 1282, 1827, 2230, 2328-2329, 2336, 2350,
+  2364-2365 (agg), 2370, 2772 (export), 2899-2902 (import).
+- **`outgoing` (PK=channel):** 1757/1763, 1772/1779, 2471, 2651, 2770 (export),
+  2896 (import).
+- **`incoming` (PK=handle,channel):** 1226-1227, 1247-1248, 1349-1350,
+  1363-1364, 1496-1497, 1521-1522, 1605-1606, 1624-1625, 2134-2135,
+  2364 (agg), 2382-2383, 2423-2424, 2447-2448, 2464-2465, 2486-2487,
+  2503-2504, 2543-2544, 2609/2637 (`handle LIKE`, cross-network), 2767/2882.
+- **`outgoing_recipients` (PK=channel,handle):** 1211-1212, 1655-1656,
+  2468-2469, 2612-2614/2639-2641 (`handle LIKE`), 2777/2913.
+- **`pending` (PK=channel=_pending_key):** 502 (wipe), 1160/1167, 1174-1175,
+  1229-1232, 1250-1253, 1423-1426, 1428-1430 (bare fallback), 1435, 1437-1440.
+- **`pending_inbound` (PK=handle,channel):** 1367-1370, 2402-2404, 2409-2411,
+  2443-2444.
+- **AAD (bare):** def 551-552; calls 1868 (encrypt), 2162 (decrypt).
+- **Wire `c=` (bare):** parse 1061/1089/1127; build 1178, 1215, 1644.
+- **SIG/KDF (bare):** payload defs 643-694; sign 1170/1195-1197/1641; verify
+  1269-1272/1410-1418/1536-1544; KDF info 1190/1444/1597/1637.
+- **Network label:** `localvar_server` 1005-1007/2196-2197/2317-2318; hook
+  `server` param in `hook_irc_out_privmsg` (2040), `hook_irc_in_privmsg` (2101),
+  `hook_irc_in_notice` (2248).
+- **Handshake verbatim-store:** `handle_keyreq` `ctx=req["channel"]` (1278) →
+  1282/1349-1350/1363-1364/1367-1370; `handle_keyrsp` `ctx=rsp["channel"]`
+  (1408) → 1424-1439/1496-1497/1521-1522; `handle_rekey` `ctx=rk["channel"]`
+  (1546) → 1605-1606/1624-1625.
+
+### irssi (`scripts/irssi/rpe2e.pl`)
+
+- **Helpers producing the key:** `_ctx_for_target` (515-519),
+  `_resolve_ctx_for_command` (1014-1021), `_gate_decide` `$ctx=` (1669/1681),
+  `_decrypt_wire_message` `$ctx` (1769), `signal_event_privmsg` `$ctx_target`
+  (1822-1826), `_pending_key` (639-641, uses `|`).
+- **`$kr->{channels}`:** 741, 1035, 1046, 1060, 1076 (agg), 1143, 1658, 1677,
+  1684, 1781, 1386-1387 (export), 1435 (import).
+- **`$kr->{outgoing}`:** 610/615, 625/631, 1214, 1346/1349, 1690,
+  1381-1382 (export), 1427 (import).
+- **`$kr->{incoming}` (key `"$handle|$ctx"`):** 718, 727, 773, 779, 847, 921,
+  1075 (agg), 1103-1105, 1125, 1131, 1178, 1195, 1210, 1231, 1256-1259,
+  1270-1272, 1288, 1313-1315, 1331-1333, 1376-1377, 1416-1418, 1777.
+- **`$kr->{outgoing_recipients}` (key `"$channel|$handle"`):** 697, 932-934,
+  1213, 1256-1259, 1313-1315, 1331-1333, 1391, 1441-1443.
+- **`$kr->{pending}` (key `_pending_key`):** 648/652/657, 719, 730, 809,
+  811 (bare fallback), 1256-1259.
+- **`$kr->{pending_inbound}` (key `"$handle|$ctx"`):** 785, 1162, 1194,
+  1256-1259, 1862.
+- **AAD (bare):** def 321; calls 1558 (encrypt), 1796 (decrypt).
+- **Wire `c=` (bare):** parse 432/460/492; build 666, 706, 870.
+- **SIG/KDF (bare):** payload defs 396-408; sign 656/684/866; verify
+  740/808/885; KDF info 679/816/862/905.
+- **Network label:** ABSENT — add `$server->{tag}`; thread it into
+  `handle_keyreq/keyrsp/rekey` (734/803/880), which currently lack `$server`.
+- **Handshake verbatim-store:** `handle_keyreq` `$ctx=$req->{channel}` (738) →
+  741/773/779/785; `handle_keyrsp` `$ctx=$rsp->{channel}` (807) →
+  809/811/847; `handle_rekey` `$ctx=$rk->{channel}` (884) → 921.
+
+## Test plan for the follow-up
+
+- Unit/headless: scoped storage round-trips; AAD/`c=`/sig verified BARE (a wire
+  produced under `scoped(netA,#x)` must decrypt with `build_aad("#x", …)`).
+- Interop: script↔script AND script↔Rust — same peer, same `#chan`, on two
+  networks must NOT share a key; a wire from one must not AEAD-verify under the
+  other's context.
+- Migration: single-network keyring with bare rows adopts to scoped and keeps
+  working; multi-network keyring with a same-name channel refuses rather than
+  cross-contaminating (mirror `multi_network_upgraded_legacy_dm_refuses_*`).

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -103,23 +103,31 @@ sub empty_keyring {
     };
 }
 
-sub load_keyring {
-    return empty_keyring() unless -f $keyring_path;
-    open my $fh, '<', $keyring_path or return empty_keyring();
+# Load the keyring, distinguishing a genuine read/parse error from an absent
+# file. Returns ($kr, $ok): $ok=0 means the file EXISTS but could not be read
+# or parsed — the outbound gate must fail closed on that (an enabled config may
+# be present but unreadable, so refusing beats risking plaintext). An absent
+# file is ($empty, 1): there is legitimately no E2E state.
+sub _load_keyring_checked {
+    return (empty_keyring(), 1) unless -f $keyring_path;
+    open my $fh, '<', $keyring_path or return (empty_keyring(), 0);
     local $/;
     my $json = <$fh>;
     close $fh;
     my $kr;
     eval { $kr = decode_json($json) };
-    if ($@ || ref($kr) ne 'HASH') {
-        Irssi::print("[E2E] keyring corrupt, starting fresh");
-        return empty_keyring();
-    }
+    return (empty_keyring(), 0) if $@ || ref($kr) ne 'HASH';
     for my $k (qw(identity peers outgoing incoming channels pending outgoing_recipients pending_inbound)) {
         $kr->{$k} //= {};
     }
     $kr->{autotrust} //= [];
     $kr->{pending_trust_change} //= [];
+    return ($kr, 1);
+}
+
+sub load_keyring {
+    my ($kr, $ok) = _load_keyring_checked();
+    Irssi::print("[E2E] keyring corrupt, starting fresh") if !$ok;
     return $kr;
 }
 
@@ -358,12 +366,21 @@ sub parse_wire {
 
 sub split_plaintext {
     my ($text) = @_;
+    return split_plaintext_budget($text, $MAX_PT_PER_CHUNK);
+}
+
+# split_plaintext with a caller-chosen per-chunk byte budget — mirrors Rust
+# src/e2e/chunker.rs::split_plaintext_budget. Used by the CTCP ACTION splitter,
+# whose per-piece budget must leave room for the \x01ACTION …\x01 framing each
+# piece is wrapped in afterwards. The MAX_CHUNKS cap applies regardless.
+sub split_plaintext_budget {
+    my ($text, $max_per_chunk) = @_;
     die "empty plaintext" unless defined $text && length $text;
     my $bytes = encode('UTF-8', $text);
     my @chunks;
     my $i = 0;
     while ($i < length($bytes)) {
-        my $j = $i + $MAX_PT_PER_CHUNK;
+        my $j = $i + $max_per_chunk;
         $j = length($bytes) if $j > length($bytes);
         while ($j > $i && $j < length($bytes) && ((ord(substr($bytes, $j, 1)) & 0xC0) == 0x80)) {
             $j--;
@@ -1522,24 +1539,217 @@ sub cmd_e2e {
     }
 }
 
+# ── Outbound E2E gate (F1) — mirror of e2e_encrypt_or_passthrough ─────────
+#
+# irssi's high-level `send text` signal only carries plain typed lines; `/me`
+# (ACTION), `/msg`, `/say`, `/amsg`, … never pass through it, so they used to
+# reach the wire as PLAINTEXT in an E2E conversation. The authoritative fix is
+# a low-level chokepoint on `server sending command` (the same interception
+# point the FiSH encryption script uses): every PRIVMSG about to hit the wire —
+# regardless of the command that produced it — passes through the gate below.
+# It NEVER downgrades an E2E-enabled conversation to plaintext; every refusal is
+# visible.
+
+# Themed refusal reasons (mirror Rust E2eRefusal::user_message).
+my $REFUSE_NO_HANDLE = "cannot encrypt PM without peer handle — wait for a message from them first";
+my $REFUSE_KEYRING   = "cannot encrypt — keyring read failed; message NOT sent (E2E stays on)";
+my $REFUSE_ENCRYPT   = "encryption failed — message NOT sent as plaintext (use /e2e off to send cleartext)";
+my $BOT_BYPASS_WARN  = "bot-style message to %s sent in CLEARTEXT — channel lines starting with '.' or '!' bypass encryption for bots";
+
+# Encrypt plaintext under session key $sk for wire context $ctx; returns an
+# arrayref of wire lines (one per chunk). Shared by the gate and signal_send_text
+# so the wire framing has a single source of truth.
+sub _encrypt_plain_wire {
+    my ($sk, $ctx, $plain) = @_;
+    my $chunks = split_plaintext($plain);
+    my $total = scalar @$chunks;
+    my $msgid = _raw(random_bytes(8));
+    my $ts = now_unix();
+    my @out;
+    my $idx = 0;
+    for my $chunk (@$chunks) {
+        $idx++;
+        my $aad = build_aad($ctx, $msgid, $ts, $idx, $total);
+        my ($nonce, $ct) = aead_encrypt($sk, $aad, $chunk);
+        push @out, encode_wire($msgid, $ts, $idx, $total, $nonce, $ct);
+    }
+    return \@out;
+}
+
+# Encrypt a \x01ACTION …\x01 CTCP frame — mirror of Rust
+# E2eManager::encrypt_outgoing_ctcp. A frame fitting one chunk encrypts as-is;
+# a longer ACTION splits into independent, individually-wrapped \x01ACTION
+# piece\x01 frames (never fragmenting the CTCP envelope across bare chunks).
+# Byte length, not character length, gates the one-chunk case.
+sub _encrypt_ctcp_wire {
+    my ($sk, $ctx, $frame) = @_;
+    my $action_prefix = "\x01ACTION ";
+    my $action_framing = length($action_prefix) + 1;   # +1 for trailing \x01
+    if (length(encode('UTF-8', $frame)) <= $MAX_PT_PER_CHUNK) {
+        return _encrypt_plain_wire($sk, $ctx, $frame);
+    }
+    die "CTCP frame exceeds one encrypted chunk and cannot be split"
+        unless $frame =~ /^\Q$action_prefix\E/ && substr($frame, -1) eq "\x01";
+    my $body = substr($frame, length($action_prefix), length($frame) - length($action_prefix) - 1);
+    my $budget = $MAX_PT_PER_CHUNK - $action_framing;
+    my $pieces = split_plaintext_budget($body, $budget);
+    my @out;
+    for my $piece (@$pieces) {
+        my $piece_str = decode('UTF-8', $piece);
+        push @out, @{ _encrypt_plain_wire($sk, $ctx, $action_prefix . $piece_str . "\x01") };
+    }
+    return \@out;
+}
+
+# Best-effort REKEY distribution that never dies. A distribution failure must
+# NOT refuse the user's message: the key has already rotated (a revoked peer is
+# excluded regardless) and a trusted peer that misses the REKEY re-handshakes on
+# its next undecryptable ciphertext (auto-KEYREQ) — mirroring the Rust gate,
+# whose REKEY NOTICEs are queued/retried rather than gating the send.
+sub _distribute_rekey_safe {
+    my ($server, $kr, $channel, $new_sk) = @_;
+    eval { _distribute_rekey($server, $kr, $channel, $new_sk); 1 }
+        or _dbg("_distribute_rekey_safe: distribution failed for $channel: $@");
+}
+
+# The gate decision for one outgoing PRIVMSG body. Returns ($action, $payload):
+#   ('pass',   undef)      send $body unchanged (no E2E state / escape hatch)
+#   ('cipher', [wire, …])  send these encrypted lines, drop the original
+#   ('refuse', reason)     drop; caller shows the [E2E] reason
+#   ('bypass', warn|undef) channel bot bypass; send plaintext, maybe warn
+sub _gate_decide {
+    my ($server, $target, $body) = @_;
+    my $is_channel = $target =~ $CHANNEL_PREFIX_RE;
+
+    # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape hatch,
+    # exactly as the Rust client leaves /ctcp and /version cleartext.
+    my $is_ctcp   = length($body) >= 2 && substr($body, 0, 1) eq "\x01" && substr($body, -1) eq "\x01";
+    my $is_action = $body =~ /^\x01ACTION / && substr($body, -1) eq "\x01";
+    return ('pass', undef) if $is_ctcp && !$is_action;
+
+    my ($kr, $ok) = _load_keyring_checked();
+
+    # Bot-command bypass: `.cmd`/`!cmd` go out unencrypted so channel bots can
+    # parse them. CHANNEL-ONLY and SINGLE-LINE; DMs never bypass. Warn whenever
+    # we cannot POSITIVELY rule E2E out (enabled OR a keyring read error) so the
+    # cleartext is never a silent surprise.
+    if ($is_channel && $body =~ /^[.!]/ && index($body, "\n") < 0) {
+        my $enabled = $kr->{channels}{$target} && ($kr->{channels}{$target}{enabled} // 0);
+        my $warn = (!$ok || $enabled) ? sprintf($BOT_BYPASS_WARN, $target) : undef;
+        return ('bypass', $warn);
+    }
+
+    # A genuine keyring read error means an enabled config may exist but be
+    # unreadable — refuse rather than risk plaintext (fail-closed).
+    return ('refuse', $REFUSE_KEYRING) unless $ok;
+
+    my $ctx;
+    if ($is_channel) {
+        $ctx = $target;
+    } else {
+        my $handle = _find_handle_by_nick($kr, $target);
+        unless (defined $handle) {
+            # No cached handle → no `@<handle>` config can exist for this nick.
+            # Refuse only if an enabled legacy bare-nick row exists; otherwise
+            # plaintext passthrough is safe (genuinely no E2E state).
+            my $cfg = $kr->{channels}{$target};
+            return ('refuse', $REFUSE_NO_HANDLE) if $cfg && ($cfg->{enabled} // 0);
+            return ('pass', undef);
+        }
+        $ctx = '@' . $handle;
+    }
+
+    my $cfg = $kr->{channels}{$ctx};
+    return ('pass', undef) unless $cfg && ($cfg->{enabled} // 0);
+
+    my ($sk, $had_pending) = _get_or_generate_outgoing_key_with_rotation($kr, $ctx);
+    _distribute_rekey_safe($server, $kr, $ctx, $sk) if $had_pending;
+    save_keyring($kr);
+    my $wires = eval {
+        $is_action ? _encrypt_ctcp_wire($sk, $ctx, $body)
+                   : _encrypt_plain_wire($sk, $ctx, $body);
+    };
+    if ($@ || !defined $wires) {
+        _dbg("_gate_decide encrypt failed for $ctx: $@");
+        return ('refuse', $REFUSE_ENCRYPT);
+    }
+    return ('cipher', $wires);
+}
+
+# Fail-closed wrapper: any unexpected error in the decision resolves to a
+# refusal, because at that point we can no longer rule out an enabled E2E
+# context and must not leak plaintext.
+sub _e2e_gate_wire {
+    my ($server, $target, $body) = @_;
+    my @res = eval { _gate_decide($server, $target, $body) };
+    if ($@) {
+        _dbg("_e2e_gate_wire OUTER EXCEPTION for $target: $@");
+        return ('refuse', $REFUSE_KEYRING);
+    }
+    return @res;
+}
+
+sub signal_server_sending_command {
+    my ($server, $data) = @_;
+    return unless $server && defined $data;
+    my $line = $data;
+    $line =~ s/\r*\n*\z//;   # some paths append CRLF; never let it into the body
+    # Only PRIVMSG carries user message content. NOTICE (KEYREQ/KEYRSP/REKEY)
+    # and every other command pass through untouched.
+    return unless $line =~ /^PRIVMSG\s+(\S+)\s+:?(.*)$/s;
+    my ($target, $body) = ($1, $2);
+    # Re-entrancy guard: a STRUCTURALLY valid wire chunk is our own re-emit from
+    # _send_raw_privmsg. Keyed on parse_wire (not a bare +RPE2E01 prefix) so a
+    # user command like "/msg bob +RPE2E01 secret" still goes through the gate
+    # instead of leaking as plaintext.
+    return if parse_wire($body);
+    my ($action, $payload) = _e2e_gate_wire($server, $target, $body);
+    return if $action eq 'pass';
+    if ($action eq 'bypass') {
+        _prnt_warn(_notice_witem_for_ctx($server, $target, $target), $payload) if defined $payload;
+        return;
+    }
+    if ($action eq 'refuse') {
+        _prnt_err(_notice_witem_for_ctx($server, $target, $target), $payload);
+        Irssi::signal_stop();   # drop the plaintext line — never reaches the wire
+        return;
+    }
+    # cipher: suppress the original and emit the encrypted chunks ourselves.
+    Irssi::signal_stop();
+    _send_raw_privmsg($server, $target, $_) for @$payload;
+}
+
 sub signal_send_text {
     my ($data, $server, $witem) = @_;
     return unless $witem;
     return if !defined($data) || $data =~ m{^/};
     my $target = $witem->{name};
     # Bot-command bypass is CHANNEL-ONLY: `.cmd`/`!cmd` lines go out
-    # unencrypted so channel bots can parse them. DMs never bypass —
-    # prose starting with '.'/'!' in an E2E DM must still encrypt.
+    # unencrypted so channel bots can parse them (the CLEARTEXT warning is
+    # shown by the server-sending-command gate). DMs never bypass — prose
+    # starting with '.'/'!' in an E2E DM must still encrypt.
     return if $target =~ $CHANNEL_PREFIX_RE && $data =~ m{^[.!]};
-    my $kr = load_keyring();
+    my ($kr, $ok) = _load_keyring_checked();
+    unless ($ok) {
+        # Fail closed: a keyring read error may hide an enabled config.
+        _prnt_err($witem, $REFUSE_KEYRING);
+        Irssi::signal_stop();
+        return;
+    }
     my $ctx;
     if ($target =~ $CHANNEL_PREFIX_RE) {
         $ctx = $target;
     } else {
         my $handle = _find_handle_by_nick($kr, $target);
         unless (defined $handle) {
-            _prnt_err($witem, "cannot resolve handle for $target — has the user spoken yet?");
-            Irssi::signal_stop();
+            # No cached handle → no `@<handle>` config can exist. Refuse only if
+            # an enabled legacy bare-nick row exists (never downgrade E2E to
+            # plaintext); otherwise let the plain DM pass through normally.
+            my $cfg = $kr->{channels}{$target};
+            if ($cfg && ($cfg->{enabled} // 0)) {
+                _prnt_err($witem, $REFUSE_NO_HANDLE);
+                Irssi::signal_stop();
+            }
             return;
         }
         $ctx = '@' . $handle;
@@ -1547,24 +1757,15 @@ sub signal_send_text {
     my $cfg = $kr->{channels}{$ctx};
     return unless $cfg && ($cfg->{enabled} // 0);
     my ($sk, $had_pending) = _get_or_generate_outgoing_key_with_rotation($kr, $ctx);
-    _distribute_rekey($server, $kr, $ctx, $sk) if $had_pending;
-    my $chunks = eval { split_plaintext($data) };
-    if ($@) {
-        _prnt_err($witem, "encrypt failed: $@");
+    _distribute_rekey_safe($server, $kr, $ctx, $sk) if $had_pending;
+    save_keyring($kr);
+    my $wires = eval { _encrypt_plain_wire($sk, $ctx, $data) };
+    if ($@ || !defined $wires) {
+        _prnt_err($witem, $REFUSE_ENCRYPT);
         Irssi::signal_stop();
         return;
     }
-    my $msgid = _raw(random_bytes(8));
-    my $ts = now_unix();
-    my $idx = 0;
-    for my $chunk (@$chunks) {
-        $idx++;
-        my $aad = build_aad($ctx, $msgid, $ts, $idx, scalar @$chunks);
-        my ($nonce, $ct) = aead_encrypt($sk, $aad, $chunk);
-        my $wire = encode_wire($msgid, $ts, $idx, scalar @$chunks, $nonce, $ct);
-        _send_raw_privmsg($server, $target, $wire);
-    }
-    save_keyring($kr);
+    _send_raw_privmsg($server, $target, $_) for @$wires;
     _emit_own_message($server, $witem, $target, $data);
     Irssi::signal_stop();
 }
@@ -1698,6 +1899,9 @@ ensure_identity();
 
 Irssi::command_bind('e2e', \&cmd_e2e);
 Irssi::signal_add_first('send text', \&signal_send_text);
+# Authoritative outbound fail-closed gate (F1): every PRIVMSG on the wire —
+# `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
+Irssi::signal_add_first('server sending command', \&signal_server_sending_command);
 Irssi::signal_add_first('message public', \&signal_message_public);
 Irssi::signal_add_first('message private', \&signal_message_private);
 Irssi::signal_add_first('ctcp reply RPEE2E', \&signal_ctcp_reply_rpee2e);

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -1770,10 +1770,19 @@ sub signal_send_text {
     Irssi::signal_stop();
 }
 
+# Decrypt one RPE2E wire message. Returns ($handled, $decoded):
+#   (0, undef)      — not an RPE2E wire; caller lets irssi handle it
+#   (1, undef)      — handled by dropping (ts skew / no session→KEYREQ /
+#                     decrypt fail); this sub already called signal_stop()
+#   (1, $plaintext) — decrypted; caller re-drives the DECRYPTED text through
+#                     the pipeline (so a \x01ACTION…\x01 frame renders as an
+#                     action instead of raw control bytes)
+# `$target` is the CONTEXT target: the channel for channel messages, the
+# SENDER's nick for DMs (DM context = @<sender handle>).
 sub _decrypt_wire_message {
     my ($server, $msg, $nick, $host, $target) = @_;
     my $wire = parse_wire($msg);
-    return 0 unless $wire;
+    return (0, undef) unless $wire;
     my $handle = $host;
     my $ctx = _ctx_for_target($target, $handle);
     my $kr = load_keyring();
@@ -1781,7 +1790,7 @@ sub _decrypt_wire_message {
     if (abs(now_unix() - $wire->{ts}) > $TS_TOLERANCE) {
         _prnt_dbg($server, $ctx, $nick, "drop ciphertext from $nick ($handle): timestamp skew");
         Irssi::signal_stop();
-        return 1;
+        return (1, undef);
     }
     my $row = $kr->{incoming}{"$handle|$ctx"};
     if (!$row || ($row->{status} // '') ne 'trusted') {
@@ -1800,30 +1809,44 @@ sub _decrypt_wire_message {
             }
         }
         Irssi::signal_stop();
-        return 1;
+        return (1, undef);
     }
     my $aad = build_aad($ctx, $wire->{msgid}, $wire->{ts}, $wire->{part}, $wire->{total});
     my $pt = aead_decrypt(b64d($row->{sk}), $wire->{nonce}, $aad, $wire->{ct});
     unless (defined $pt) {
         _prnt_dbg($server, $ctx, $nick, "decrypt failed for ($handle,$ctx)");
         Irssi::signal_stop();
-        return 1;
+        return (1, undef);
     }
     my $decoded = eval { decode('UTF-8', $pt, FB_DEFAULT) };
     $decoded = decode('UTF-8', $pt) if !defined $decoded;
-    Irssi::signal_continue($server, $decoded, $nick, $host, $target);
-    return 1;
+    return (1, $decoded);
 }
 
-sub signal_message_public {
-    my ($server, $msg, $nick, $host, $target) = @_;
-    _decrypt_wire_message($server, $msg, $nick, $host, $target);
-}
-
-sub signal_message_private {
-    my ($server, $msg, $nick, $host, $target) = @_;
-    my $query = $nick;
-    _decrypt_wire_message($server, $msg, $nick, $host, $query);
+# F2: decrypt on `event privmsg` — the irssi analog of weechat's raw-line
+# `irc_in2_privmsg` modifier, firing BEFORE irssi splits out CTCP/ACTION. An
+# encrypted ACTION travels on the wire as `+RPE2E01…` (no \x01), so decrypting
+# it here yields `\x01ACTION…\x01` which re-enters the pipeline and renders as a
+# proper action; decrypting later (on `message public`/`private`, post-CTCP-
+# split) rendered raw control characters instead.
+sub signal_event_privmsg {
+    my ($server, $data, $nick, $host) = @_;
+    return unless defined $data;
+    # `$data` is "target :text" (the PRIVMSG params). For a channel, target is
+    # the channel; for a DM, target is OUR nick and the sender is $nick.
+    my ($target, $text) = $data =~ /^(\S+)\s+:?(.*)$/s;
+    return unless defined $target && defined $text;
+    return unless parse_wire($text);   # not RPE2E → let irssi handle normally
+    my $is_channel = $target =~ $CHANNEL_PREFIX_RE;
+    # Context target: channel → the channel; DM → the SENDER's nick (DM context
+    # is keyed off the sender's handle, matching the old message-private path).
+    my $ctx_target = $is_channel ? $target : $nick;
+    my ($handled, $decoded) = _decrypt_wire_message($server, $text, $nick, $host, $ctx_target);
+    return unless $handled;
+    # Re-drive the DECRYPTED text through the same event, preserving the wire's
+    # original target so routing (channel vs query) is unchanged. irssi then
+    # performs the CTCP/ACTION split on cleartext.
+    Irssi::signal_continue($server, "$target :$decoded", $nick, $host) if defined $decoded;
 }
 
 sub _handle_rpee2e_ctcp_reply {
@@ -1902,8 +1925,9 @@ Irssi::signal_add_first('send text', \&signal_send_text);
 # Authoritative outbound fail-closed gate (F1): every PRIVMSG on the wire —
 # `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
 Irssi::signal_add_first('server sending command', \&signal_server_sending_command);
-Irssi::signal_add_first('message public', \&signal_message_public);
-Irssi::signal_add_first('message private', \&signal_message_private);
+# F2: decrypt on the raw PRIVMSG event, BEFORE irssi's CTCP/ACTION split, so
+# an encrypted ACTION renders as an action rather than raw control characters.
+Irssi::signal_add_first('event privmsg', \&signal_event_privmsg);
 Irssi::signal_add_first('ctcp reply RPEE2E', \&signal_ctcp_reply_rpee2e);
 Irssi::signal_add_first('ctcp reply', \&signal_ctcp_reply_generic);
 Irssi::signal_add_first('default ctcp reply', \&signal_default_ctcp_reply_generic);

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -1715,15 +1715,21 @@ sub _e2e_gate_wire {
     return @res;
 }
 
-# THE single authoritative outbound gate. Every PRIVMSG irssi is about to send —
-# from plain typed text, `/me`, `/msg`, `/say`, `/amsg`, or a script — passes
-# through here (there is no separate `send text` handler; irssi's own command
-# layer produces the local echo, and this gate rewrites only the wire).
-sub signal_server_sending_command {
-    my ($server, $data) = @_;
-    return unless $server && defined $data;
-    my $line = $data;
-    $line =~ s/\r*\n*\z//;   # some paths append CRLF; never let it into the body
+# THE single authoritative outbound gate, hooked on `server outgoing modify` —
+# the raw-line signal irssi fires for EVERY line it is about to write to the
+# socket (the analog of weechat's `irc_out1_privmsg`). Every PRIVMSG — from
+# plain typed text, `/me`, `/msg`, `/say`, `/amsg`, or a script — passes through
+# here; irssi's own command/send-text layer produces the local echo, and this
+# gate rewrites only the wire. `$data` is a SCALAR REF to the outgoing line
+# (mutable): we DROP a line by blanking `$$data` (an empty line is silently
+# ignored by the server per RFC 1459), which does not depend on signal_stop's
+# behavior for `modify` signals — a leak here would be catastrophic, so we never
+# rely on it alone.
+sub signal_server_outgoing {
+    my ($server, $data, $crlf) = @_;
+    return unless $server && ref($data) eq 'SCALAR' && defined $$data;
+    my $line = $$data;
+    $line =~ s/\r*\n*\z//;   # the raw line may carry a trailing CRLF
     # Only PRIVMSG carries user message content. NOTICE (KEYREQ/KEYRSP/REKEY)
     # and every other command pass through untouched.
     return unless $line =~ /^PRIVMSG\s+(\S+)\s+:?(.*)$/s;
@@ -1737,19 +1743,22 @@ sub signal_server_sending_command {
     return if $action eq 'pass';
     if ($action eq 'bypass') {
         _prnt_warn(_notice_witem_for_ctx($server, $target, $target), $payload) if defined $payload;
-        return;
+        return;   # leave $$data unchanged — the plaintext bot command goes out
     }
     if ($action eq 'refuse') {
         # irssi's command layer already echoed the plaintext locally, so make it
-        # explicit that nothing was delivered (the wire line is dropped below).
+        # explicit that nothing was delivered.
         _prnt_err(_notice_witem_for_ctx($server, $target, $target),
                   "$payload — the message shown above was NOT delivered");
-        Irssi::signal_stop();   # drop the plaintext line — never reaches the wire
+        $$data = "";            # drop the plaintext line — never reaches the wire
+        Irssi::signal_stop();
         return;
     }
-    # cipher: suppress the original and emit the encrypted chunks ourselves.
-    Irssi::signal_stop();
+    # cipher: emit the encrypted chunks ourselves (in order, before the original
+    # line is written), then blank the original so the plaintext never goes out.
     _send_raw_privmsg($server, $target, $_) for @$payload;
+    $$data = "";
+    Irssi::signal_stop();
 }
 
 # Decrypt one RPE2E wire message. Returns ($handled, $decoded):
@@ -1919,10 +1928,11 @@ sub signal_default_ctcp_reply_generic {
 ensure_identity();
 
 Irssi::command_bind('e2e', \&cmd_e2e);
-# THE single authoritative outbound fail-closed gate (F1): every PRIVMSG on the
-# wire — plain typed text, `/me`, `/msg`, `/say`, `/amsg`, scripts — passes
-# through here. irssi's own command layer produces the local echo.
-Irssi::signal_add_first('server sending command', \&signal_server_sending_command);
+# THE single authoritative outbound fail-closed gate (F1): `server outgoing
+# modify` is the raw-line signal irssi fires for every line about to hit the
+# socket, so every PRIVMSG — plain typed text, `/me`, `/msg`, `/say`, `/amsg`,
+# scripts — passes through here. irssi's own layer produces the local echo.
+Irssi::signal_add_first('server outgoing modify', \&signal_server_outgoing);
 # F2: decrypt on the raw PRIVMSG event, BEFORE irssi's CTCP/ACTION split, so
 # an encrypted ACTION renders as an action rather than raw control characters.
 Irssi::signal_add_first('event privmsg', \&signal_event_privmsg);

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -1011,20 +1011,6 @@ sub _send_raw_privmsg {
     $server->send_raw_now("PRIVMSG $target :$body");
 }
 
-sub _emit_own_message {
-    my ($server, $witem, $target, $plain) = @_;
-    return unless $server && $witem;
-    if ($target =~ $CHANNEL_PREFIX_RE) {
-        eval { Irssi::signal_emit('message own_public', $server, $plain, $target) };
-    } else {
-        eval { Irssi::signal_emit('message own_private', $server, $plain, $target, $target) };
-    }
-    if ($@) {
-        my $nick = $server->{nick} // '';
-        $witem->print("<$nick> $plain", Irssi::MSGLEVEL_PUBLIC());
-    }
-}
-
 sub _resolve_ctx_for_command {
     my ($kr, $witem, $nick) = @_;
     return undef unless $witem;
@@ -1557,8 +1543,8 @@ my $REFUSE_ENCRYPT   = "encryption failed — message NOT sent as plaintext (use
 my $BOT_BYPASS_WARN  = "bot-style message to %s sent in CLEARTEXT — channel lines starting with '.' or '!' bypass encryption for bots";
 
 # Encrypt plaintext under session key $sk for wire context $ctx; returns an
-# arrayref of wire lines (one per chunk). Shared by the gate and signal_send_text
-# so the wire framing has a single source of truth.
+# arrayref of wire lines (one per chunk). Shared by the plain and ACTION gate
+# paths so the wire framing has a single source of truth.
 sub _encrypt_plain_wire {
     my ($sk, $ctx, $plain) = @_;
     my $chunks = split_plaintext($plain);
@@ -1617,9 +1603,44 @@ sub _distribute_rekey_safe {
 #   ('cipher', [wire, …])  send these encrypted lines, drop the original
 #   ('refuse', reason)     drop; caller shows the [E2E] reason
 #   ('bypass', warn|undef) channel bot bypass; send plaintext, maybe warn
+# Strip a leading STATUSMSG prefix (@#chan, +#chan, %#chan, …): a message to a
+# channel subset is still that channel for E2E purposes. The lookahead keeps a
+# real channel name whose first char is itself a channel prefix (#, &, !, +)
+# untouched — only a non-channel char sitting in front of a channel prefix is
+# stripped. Without this, `/msg @#secret …` classified as a DM to a bogus nick
+# and leaked plaintext to the channel ops on an E2E-enabled channel.
+sub _strip_statusmsg {
+    my ($target) = @_;
+    $target =~ s/^[\@%+&~]+(?=[#&!+])//;
+    return $target;
+}
+
+# Resolve a DM peer's ident@host: LIVE first (an open query or a shared channel
+# carries the peer's current ident@host, which a nick change does NOT alter),
+# then the persisted cache by last_nick. Live resolution is what stops a renamed
+# E2E peer from falling through to a plaintext send — the cache's last_nick can
+# be stale (there is no 'event nick' handler), but the handle is unchanged and
+# the live query/channel record still has it. Mirrors weechat's nicklist/query
+# resolution.
+sub _resolve_dm_handle {
+    my ($server, $kr, $nick) = @_;
+    if ($server) {
+        my $q = eval { $server->query_find($nick) };
+        return $q->{address} if $q && $q->{address};
+        for my $ch (eval { $server->channels() }) {
+            my $n = eval { $ch->nick_find($nick) };
+            return $n->{host} if $n && $n->{host};
+        }
+    }
+    return _find_handle_by_nick($kr, $nick);
+}
+
 sub _gate_decide {
     my ($server, $target, $body) = @_;
-    my $is_channel = $target =~ $CHANNEL_PREFIX_RE;
+    # STATUSMSG targets (@#chan, +#chan) address a channel subset — classify and
+    # key them by the underlying channel, never as a DM.
+    my $chan = _strip_statusmsg($target);
+    my $is_channel = $chan =~ $CHANNEL_PREFIX_RE;
 
     # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape hatch,
     # exactly as the Rust client leaves /ctcp and /version cleartext.
@@ -1634,8 +1655,8 @@ sub _gate_decide {
     # we cannot POSITIVELY rule E2E out (enabled OR a keyring read error) so the
     # cleartext is never a silent surprise.
     if ($is_channel && $body =~ /^[.!]/ && index($body, "\n") < 0) {
-        my $enabled = $kr->{channels}{$target} && ($kr->{channels}{$target}{enabled} // 0);
-        my $warn = (!$ok || $enabled) ? sprintf($BOT_BYPASS_WARN, $target) : undef;
+        my $enabled = $kr->{channels}{$chan} && ($kr->{channels}{$chan}{enabled} // 0);
+        my $warn = (!$ok || $enabled) ? sprintf($BOT_BYPASS_WARN, $chan) : undef;
         return ('bypass', $warn);
     }
 
@@ -1645,13 +1666,14 @@ sub _gate_decide {
 
     my $ctx;
     if ($is_channel) {
-        $ctx = $target;
+        $ctx = $chan;
     } else {
-        my $handle = _find_handle_by_nick($kr, $target);
-        unless (defined $handle) {
-            # No cached handle → no `@<handle>` config can exist for this nick.
-            # Refuse only if an enabled legacy bare-nick row exists; otherwise
-            # plaintext passthrough is safe (genuinely no E2E state).
+        my $handle = _resolve_dm_handle($server, $kr, $target);
+        unless (defined $handle && length $handle) {
+            # Nothing resolvable → no `@<handle>` config can exist for this nick
+            # (a handshake would have cached one, and live resolution catches a
+            # rename). Refuse only if an enabled legacy bare-nick row exists;
+            # otherwise plaintext passthrough is safe (genuinely no E2E state).
             my $cfg = $kr->{channels}{$target};
             return ('refuse', $REFUSE_NO_HANDLE) if $cfg && ($cfg->{enabled} // 0);
             return ('pass', undef);
@@ -1662,9 +1684,13 @@ sub _gate_decide {
     my $cfg = $kr->{channels}{$ctx};
     return ('pass', undef) unless $cfg && ($cfg->{enabled} // 0);
 
+    # Persist only when a key is actually generated/rotated — otherwise the
+    # existing key is returned unchanged and rewriting the whole keyring JSON on
+    # every message is wasted I/O.
+    my $pre_existing = $kr->{outgoing}{$ctx} && !($kr->{outgoing}{$ctx}{pending_rotation} // 0);
     my ($sk, $had_pending) = _get_or_generate_outgoing_key_with_rotation($kr, $ctx);
     _distribute_rekey_safe($server, $kr, $ctx, $sk) if $had_pending;
-    save_keyring($kr);
+    save_keyring($kr) unless $pre_existing;
     my $wires = eval {
         $is_action ? _encrypt_ctcp_wire($sk, $ctx, $body)
                    : _encrypt_plain_wire($sk, $ctx, $body);
@@ -1689,6 +1715,10 @@ sub _e2e_gate_wire {
     return @res;
 }
 
+# THE single authoritative outbound gate. Every PRIVMSG irssi is about to send —
+# from plain typed text, `/me`, `/msg`, `/say`, `/amsg`, or a script — passes
+# through here (there is no separate `send text` handler; irssi's own command
+# layer produces the local echo, and this gate rewrites only the wire).
 sub signal_server_sending_command {
     my ($server, $data) = @_;
     return unless $server && defined $data;
@@ -1710,64 +1740,16 @@ sub signal_server_sending_command {
         return;
     }
     if ($action eq 'refuse') {
-        _prnt_err(_notice_witem_for_ctx($server, $target, $target), $payload);
+        # irssi's command layer already echoed the plaintext locally, so make it
+        # explicit that nothing was delivered (the wire line is dropped below).
+        _prnt_err(_notice_witem_for_ctx($server, $target, $target),
+                  "$payload — the message shown above was NOT delivered");
         Irssi::signal_stop();   # drop the plaintext line — never reaches the wire
         return;
     }
     # cipher: suppress the original and emit the encrypted chunks ourselves.
     Irssi::signal_stop();
     _send_raw_privmsg($server, $target, $_) for @$payload;
-}
-
-sub signal_send_text {
-    my ($data, $server, $witem) = @_;
-    return unless $witem;
-    return if !defined($data) || $data =~ m{^/};
-    my $target = $witem->{name};
-    # Bot-command bypass is CHANNEL-ONLY: `.cmd`/`!cmd` lines go out
-    # unencrypted so channel bots can parse them (the CLEARTEXT warning is
-    # shown by the server-sending-command gate). DMs never bypass — prose
-    # starting with '.'/'!' in an E2E DM must still encrypt.
-    return if $target =~ $CHANNEL_PREFIX_RE && $data =~ m{^[.!]};
-    my ($kr, $ok) = _load_keyring_checked();
-    unless ($ok) {
-        # Fail closed: a keyring read error may hide an enabled config.
-        _prnt_err($witem, $REFUSE_KEYRING);
-        Irssi::signal_stop();
-        return;
-    }
-    my $ctx;
-    if ($target =~ $CHANNEL_PREFIX_RE) {
-        $ctx = $target;
-    } else {
-        my $handle = _find_handle_by_nick($kr, $target);
-        unless (defined $handle) {
-            # No cached handle → no `@<handle>` config can exist. Refuse only if
-            # an enabled legacy bare-nick row exists (never downgrade E2E to
-            # plaintext); otherwise let the plain DM pass through normally.
-            my $cfg = $kr->{channels}{$target};
-            if ($cfg && ($cfg->{enabled} // 0)) {
-                _prnt_err($witem, $REFUSE_NO_HANDLE);
-                Irssi::signal_stop();
-            }
-            return;
-        }
-        $ctx = '@' . $handle;
-    }
-    my $cfg = $kr->{channels}{$ctx};
-    return unless $cfg && ($cfg->{enabled} // 0);
-    my ($sk, $had_pending) = _get_or_generate_outgoing_key_with_rotation($kr, $ctx);
-    _distribute_rekey_safe($server, $kr, $ctx, $sk) if $had_pending;
-    save_keyring($kr);
-    my $wires = eval { _encrypt_plain_wire($sk, $ctx, $data) };
-    if ($@ || !defined $wires) {
-        _prnt_err($witem, $REFUSE_ENCRYPT);
-        Irssi::signal_stop();
-        return;
-    }
-    _send_raw_privmsg($server, $target, $_) for @$wires;
-    _emit_own_message($server, $witem, $target, $data);
-    Irssi::signal_stop();
 }
 
 # Decrypt one RPE2E wire message. Returns ($handled, $decoded):
@@ -1836,17 +1818,33 @@ sub signal_event_privmsg {
     # the channel; for a DM, target is OUR nick and the sender is $nick.
     my ($target, $text) = $data =~ /^(\S+)\s+:?(.*)$/s;
     return unless defined $target && defined $text;
-    return unless parse_wire($text);   # not RPE2E → let irssi handle normally
-    my $is_channel = $target =~ $CHANNEL_PREFIX_RE;
+    # STATUSMSG incoming (@#chan) still keys off the underlying channel.
+    my $chan = _strip_statusmsg($target);
+    my $is_channel = $chan =~ $CHANNEL_PREFIX_RE;
     # Context target: channel → the channel; DM → the SENDER's nick (DM context
     # is keyed off the sender's handle, matching the old message-private path).
-    my $ctx_target = $is_channel ? $target : $nick;
+    my $ctx_target = $is_channel ? $chan : $nick;
+    # _decrypt_wire_message returns (0, undef) for a non-RPE2E line (no second
+    # parse needed here), (1, undef) when it already dropped the ciphertext, or
+    # (1, $plaintext) on success.
     my ($handled, $decoded) = _decrypt_wire_message($server, $text, $nick, $host, $ctx_target);
-    return unless $handled;
+    return unless $handled && defined $decoded;
+    # A decrypted non-ACTION CTCP frame (\x01VERSION\x01, \x01PING\x01, DCC, …)
+    # must NOT be re-driven through the pipeline: irssi would interpret it and
+    # auto-answer with a PLAINTEXT NOTICE. Our own outbound side never encrypts
+    # non-ACTION CTCP (it is a cleartext escape hatch), so this is anomalous —
+    # drop it visibly instead of executing it. ACTION frames and ordinary text
+    # re-enter normally.
+    if ($decoded =~ /^\x01/ && $decoded !~ /^\x01ACTION /) {
+        _prnt_warn(_notice_witem_for_ctx($server, $ctx_target, $nick),
+                   "dropped an encrypted non-ACTION CTCP from $nick");
+        Irssi::signal_stop();
+        return;
+    }
     # Re-drive the DECRYPTED text through the same event, preserving the wire's
     # original target so routing (channel vs query) is unchanged. irssi then
     # performs the CTCP/ACTION split on cleartext.
-    Irssi::signal_continue($server, "$target :$decoded", $nick, $host) if defined $decoded;
+    Irssi::signal_continue($server, "$target :$decoded", $nick, $host);
 }
 
 sub _handle_rpee2e_ctcp_reply {
@@ -1921,9 +1919,9 @@ sub signal_default_ctcp_reply_generic {
 ensure_identity();
 
 Irssi::command_bind('e2e', \&cmd_e2e);
-Irssi::signal_add_first('send text', \&signal_send_text);
-# Authoritative outbound fail-closed gate (F1): every PRIVMSG on the wire —
-# `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
+# THE single authoritative outbound fail-closed gate (F1): every PRIVMSG on the
+# wire — plain typed text, `/me`, `/msg`, `/say`, `/amsg`, scripts — passes
+# through here. irssi's own command layer produces the local echo.
 Irssi::signal_add_first('server sending command', \&signal_server_sending_command);
 # F2: decrypt on the raw PRIVMSG event, BEFORE irssi's CTCP/ACTION split, so
 # an encrypted ACTION renders as an action rather than raw control characters.

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -1540,6 +1540,7 @@ sub cmd_e2e {
 my $REFUSE_NO_HANDLE = "cannot encrypt PM without peer handle — wait for a message from them first";
 my $REFUSE_KEYRING   = "cannot encrypt — keyring read failed; message NOT sent (E2E stays on)";
 my $REFUSE_ENCRYPT   = "encryption failed — message NOT sent as plaintext (use /e2e off to send cleartext)";
+my $REFUSE_AMBIGUOUS = "ambiguous target %s — E2E is enabled on both %s (STATUSMSG subset vs distinct channel); refusing to guess a context";
 my $BOT_BYPASS_WARN  = "bot-style message to %s sent in CLEARTEXT — channel lines starting with '.' or '!' bypass encryption for bots";
 
 # Encrypt plaintext under session key $sk for wire context $ctx; returns an
@@ -1603,16 +1604,28 @@ sub _distribute_rekey_safe {
 #   ('cipher', [wire, …])  send these encrypted lines, drop the original
 #   ('refuse', reason)     drop; caller shows the [E2E] reason
 #   ('bypass', warn|undef) channel bot bypass; send plaintext, maybe warn
-# Strip a leading STATUSMSG prefix (@#chan, +#chan, %#chan, …): a message to a
-# channel subset is still that channel for E2E purposes. The lookahead keeps a
-# real channel name whose first char is itself a channel prefix (#, &, !, +)
-# untouched — only a non-channel char sitting in front of a channel prefix is
-# stripped. Without this, `/msg @#secret …` classified as a DM to a bogus nick
-# and leaked plaintext to the channel ops on an E2E-enabled channel.
-sub _strip_statusmsg {
+# Every channel reading of a possibly-STATUSMSG-prefixed target, most-stripped
+# first; empty list → not a channel. `@#chan` has exactly one reading (#chan):
+# a message to a channel subset is still that channel for E2E purposes, and
+# without stripping, `/msg @#secret …` classified as a DM to a bogus nick and
+# leaked plaintext to the channel ops on an E2E-enabled channel. But `+` and
+# `&` are BOTH status prefixes AND channel prefixes (RFC 2811), so `+#secret`
+# is genuinely ambiguous without per-server ISUPPORT (which irssi's Perl API
+# does not expose): the voiced subset of #secret OR the distinct channel
+# "+#secret". Callers get every reading and must stay fail-closed across all
+# of them — encrypting under the one enabled reading is always safe (a peer on
+# the other reading sees undecryptable ciphertext, never plaintext).
+sub _channel_readings {
     my ($target) = @_;
-    $target =~ s/^[\@%+&~]+(?=[#&!+])//;
-    return $target;
+    $target //= '';
+    my $run = 0;
+    $run++ while $run < length($target) && index('@%+&~', substr($target, $run, 1)) >= 0;
+    my @readings;
+    for my $j (reverse 0 .. $run) {
+        my $rest = substr($target, $j);
+        push @readings, $rest if length($rest) && $rest =~ $CHANNEL_PREFIX_RE;
+    }
+    return @readings;
 }
 
 # Resolve a DM peer's ident@host: LIVE first (an open query or a shared channel
@@ -1637,10 +1650,12 @@ sub _resolve_dm_handle {
 
 sub _gate_decide {
     my ($server, $target, $body) = @_;
-    # STATUSMSG targets (@#chan, +#chan) address a channel subset — classify and
-    # key them by the underlying channel, never as a DM.
-    my $chan = _strip_statusmsg($target);
-    my $is_channel = $chan =~ $CHANNEL_PREFIX_RE;
+    # STATUSMSG targets (@#chan) address a channel subset — classify and key
+    # them by the underlying channel, never as a DM. `+#chan`/`&#chan` are
+    # ambiguous (see _channel_readings): every reading is considered below.
+    my @readings   = _channel_readings($target);
+    my $is_channel = scalar @readings;
+    my $chan       = $readings[0];
 
     # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape hatch,
     # exactly as the Rust client leaves /ctcp and /version cleartext.
@@ -1655,7 +1670,7 @@ sub _gate_decide {
     # we cannot POSITIVELY rule E2E out (enabled OR a keyring read error) so the
     # cleartext is never a silent surprise.
     if ($is_channel && $body =~ /^[.!]/ && index($body, "\n") < 0) {
-        my $enabled = $kr->{channels}{$chan} && ($kr->{channels}{$chan}{enabled} // 0);
+        my $enabled = grep { my $c = $kr->{channels}{$_}; $c && ($c->{enabled} // 0) } @readings;
         my $warn = (!$ok || $enabled) ? sprintf($BOT_BYPASS_WARN, $chan) : undef;
         return ('bypass', $warn);
     }
@@ -1666,7 +1681,12 @@ sub _gate_decide {
 
     my $ctx;
     if ($is_channel) {
-        $ctx = $chan;
+        # Encrypt under whichever reading has E2E enabled — a peer on the other
+        # reading of an ambiguous target sees ciphertext, never plaintext. Two
+        # enabled readings cannot be disambiguated locally → refuse.
+        my @on = grep { my $c = $kr->{channels}{$_}; $c && ($c->{enabled} // 0) } @readings;
+        return ('refuse', sprintf($REFUSE_AMBIGUOUS, $target, join(' and ', @on))) if @on > 1;
+        $ctx = $on[0] // $chan;
     } else {
         my $handle = _resolve_dm_handle($server, $kr, $target);
         unless (defined $handle && length $handle) {
@@ -1720,11 +1740,13 @@ sub _e2e_gate_wire {
 # socket (the analog of weechat's `irc_out1_privmsg`). Every PRIVMSG — from
 # plain typed text, `/me`, `/msg`, `/say`, `/amsg`, or a script — passes through
 # here; irssi's own command/send-text layer produces the local echo, and this
-# gate rewrites only the wire. `$data` is a SCALAR REF to the outgoing line
-# (mutable): we DROP a line by blanking `$$data` (an empty line is silently
-# ignored by the server per RFC 1459), which does not depend on signal_stop's
-# behavior for `modify` signals — a leak here would be catastrophic, so we never
-# rely on it alone.
+# gate rewrites only the wire. `$data` is the signal's GString parameter, which
+# irssi's Perl glue passes as a SCALAR REF and copies back after the handler
+# returns (perl-signals.c marshals `gstring` args via newRV + write-back). We
+# DROP a line by blanking `$$data`: the emitter — irc_server_send_and_redirect,
+# irc-servers.c — checks `if (str->len)` after the signal, so a blanked line is
+# never written to the socket, rawlogged, or redirect-matched. signal_stop()
+# only silences later handlers; the drop itself never depends on it.
 sub signal_server_outgoing {
     my ($server, $data, $crlf) = @_;
     return unless $server && ref($data) eq 'SCALAR' && defined $$data;
@@ -1769,9 +1791,10 @@ sub signal_server_outgoing {
 #                     the pipeline (so a \x01ACTION…\x01 frame renders as an
 #                     action instead of raw control bytes)
 # `$target` is the CONTEXT target: the channel for channel messages, the
-# SENDER's nick for DMs (DM context = @<sender handle>).
+# SENDER's nick for DMs (DM context = @<sender handle>). `$alt_ctxs` (optional
+# arrayref) carries the remaining readings of an ambiguous +#chan/&#chan target.
 sub _decrypt_wire_message {
-    my ($server, $msg, $nick, $host, $target) = @_;
+    my ($server, $msg, $nick, $host, $target, $alt_ctxs) = @_;
     my $wire = parse_wire($msg);
     return (0, undef) unless $wire;
     my $handle = $host;
@@ -1784,6 +1807,18 @@ sub _decrypt_wire_message {
         return (1, undef);
     }
     my $row = $kr->{incoming}{"$handle|$ctx"};
+    # An ambiguous +#chan/&#chan target carries alternate context readings:
+    # prefer one holding a trusted session for this sender (a wrong pick cannot
+    # leak — AEAD decrypt just fails and drops). The primary, most-stripped
+    # reading stays the default so auto-KEYREQ keeps keying off it.
+    if ($alt_ctxs && (!$row || ($row->{status} // '') ne 'trusted')) {
+        for my $alt (@$alt_ctxs) {
+            my $r = $kr->{incoming}{"$handle|$alt"};
+            next unless $r && ($r->{status} // '') eq 'trusted';
+            ($ctx, $row) = ($alt, $r);
+            last;
+        }
+    }
     if (!$row || ($row->{status} // '') ne 'trusted') {
         _prnt_dbg($server, $ctx, $nick, "no trusted incoming for ($handle,$ctx)");
         if (_allow_outgoing_keyreq($handle)) {
@@ -1827,16 +1862,20 @@ sub signal_event_privmsg {
     # the channel; for a DM, target is OUR nick and the sender is $nick.
     my ($target, $text) = $data =~ /^(\S+)\s+:?(.*)$/s;
     return unless defined $target && defined $text;
-    # STATUSMSG incoming (@#chan) still keys off the underlying channel.
-    my $chan = _strip_statusmsg($target);
-    my $is_channel = $chan =~ $CHANNEL_PREFIX_RE;
-    # Context target: channel → the channel; DM → the SENDER's nick (DM context
-    # is keyed off the sender's handle, matching the old message-private path).
-    my $ctx_target = $is_channel ? $chan : $nick;
+    # STATUSMSG incoming (@#chan) still keys off the underlying channel; an
+    # ambiguous +#chan/&#chan target has several readings, and decrypt below
+    # prefers whichever holds a trusted session (see _channel_readings).
+    my @readings = _channel_readings($target);
+    my $is_channel = scalar @readings;
+    # Context target: channel → most-stripped reading; DM → the SENDER's nick
+    # (DM context is keyed off the sender's handle, matching the old
+    # message-private path).
+    my $ctx_target = $is_channel ? $readings[0] : $nick;
+    my $alt_ctxs = @readings > 1 ? [@readings[1 .. $#readings]] : undef;
     # _decrypt_wire_message returns (0, undef) for a non-RPE2E line (no second
     # parse needed here), (1, undef) when it already dropped the ciphertext, or
     # (1, $plaintext) on success.
-    my ($handled, $decoded) = _decrypt_wire_message($server, $text, $nick, $host, $ctx_target);
+    my ($handled, $decoded) = _decrypt_wire_message($server, $text, $nick, $host, $ctx_target, $alt_ctxs);
     return unless $handled && defined $decoded;
     # A decrypted non-ACTION CTCP frame (\x01VERSION\x01, \x01PING\x01, DCC, …)
     # must NOT be re-driven through the pipeline: irssi would interpret it and
@@ -1925,6 +1964,31 @@ sub signal_default_ctcp_reply_generic {
     Irssi::signal_stop();
 }
 
+# The outbound gate depends on `server outgoing modify`, which exists only
+# since irssi 1.4.1 (2022-06-12). On older irssi, signal_add binds to a name
+# that is simply never emitted — no error, no gate: every message would leave
+# in PLAINTEXT while the user believes E2E is on. Refuse to load instead
+# (fail-closed at load time).
+sub _require_signal_capable_irssi {
+    my $j = eval { Irssi::parse_special('$J') } // '';
+    if ($j =~ /^(\d+)\.(\d+)(?:\.(\d+))?/) {
+        my ($maj, $min, $pat) = ($1, $2, $3 // 0);
+        return if $maj > 1
+               || ($maj == 1 && $min > 4)
+               || ($maj == 1 && $min == 4 && $pat >= 1);
+    } else {
+        # Unparseable $J — fall back to the ABI date stamp: Irssi::version()
+        # is "YYYYMMDD.HHMM", and 1.4.1 is dated 2022-06-12.
+        my $abi = eval { Irssi::version() } // 0;
+        return if $abi >= 20220612;
+    }
+    die "rpe2e requires irssi >= 1.4.1 (found: " . ($j || 'unknown')
+      . ") — the 'server outgoing modify' signal this script's outbound"
+      . " encryption gate hooks does not exist on older irssi, so messages"
+      . " would silently go out in PLAINTEXT. Not loading.\n";
+}
+
+_require_signal_capable_irssi();
 ensure_identity();
 
 Irssi::command_bind('e2e', \&cmd_e2e);

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -1893,6 +1893,19 @@ def _encrypt_ctcp_wire(sk: bytes, context: str, frame: str) -> list[str]:
     return out
 
 
+def _distribute_rekey_safe(channel: str, new_sk: bytes, server: str) -> None:
+    """Best-effort REKEY distribution that never raises. A distribution failure
+    must NOT refuse the user's message: the outgoing key has already rotated
+    (so a revoked peer is excluded regardless), and a trusted peer that misses
+    the REKEY re-handshakes on its next undecryptable ciphertext (auto-KEYREQ).
+    Any hard failure is logged; per-peer failures already warn inside
+    `_distribute_rekey`."""
+    try:
+        _distribute_rekey(channel, new_sk, server)
+    except Exception as e:
+        _dbg(f"_distribute_rekey_safe: distribution failed for {channel}: {e}")
+
+
 def _e2e_gate_wire(server: str, target: str, body: str):
     """Fail-closed outbound gate — mirror of `e2e_encrypt_or_passthrough`.
 
@@ -1921,8 +1934,13 @@ def _e2e_gate_wire(server: str, target: str, body: str):
         # full gate); DMs never bypass. Mirror of the channel-only bypass +
         # `warn_e2e_bot_bypass` visibility in the Rust gate.
         if is_channel and (body.startswith(".") or body.startswith("!")) and "\n" not in body:
+            # Warn whenever we cannot POSITIVELY confirm the channel is
+            # non-E2E: an enabled config OR a keyring read error both mean the
+            # cleartext bypass may be surprising, so the warning must show
+            # (fail-closed visibility — never silently drop the warning on a
+            # transient DB error).
             warn = None
-            if _config_enabled(target) == _ENABLED_YES:
+            if _config_enabled(target) != _ENABLED_NO:
                 warn = (
                     f"bot-style message to {target} sent in CLEARTEXT — channel "
                     "lines starting with '.' or '!' bypass encryption for bots"
@@ -1933,11 +1951,17 @@ def _e2e_gate_wire(server: str, target: str, body: str):
         if is_channel:
             context = target
         else:
-            handle = _resolve_handle_by_nick(server, target, target)
+            # Live OR cached handle resolution (mirror of Rust
+            # `resolve_query_peer_handle`): a peer who isn't currently in a
+            # shared nicklist is still resolvable from the persisted peers
+            # cache, so the `@<handle>` config the DM was enabled under is
+            # found instead of being missed into a plaintext send.
+            handle = _resolve_handle_for_command(server, target, target)
             if handle is None:
-                # No resolvable handle → no `@<handle>` config can exist.
-                # Refuse only if an enabled legacy bare-nick row exists;
-                # otherwise plaintext passthrough is safe (no E2E state).
+                # Nothing resolvable → no `@<handle>` config can exist for this
+                # nick (any handshake would have cached a handle). Refuse only
+                # if an enabled legacy bare-nick row exists; otherwise plaintext
+                # passthrough is safe (no E2E state). Fail closed on a read err.
                 legacy = _config_enabled(target)
                 if legacy == _ENABLED_ERR:
                     return ("refuse", _REFUSE_KEYRING)
@@ -1952,11 +1976,21 @@ def _e2e_gate_wire(server: str, target: str, body: str):
         if enabled == _ENABLED_NO:
             return ("pass", None)
 
-        # Enabled — encrypt. An encrypt failure REFUSES (never plaintext).
+        # Enabled — encrypt. A key-generation or encrypt failure REFUSES
+        # (never plaintext). REKEY distribution is best-effort and must NOT
+        # refuse the message: the key has already rotated (the revoked peer is
+        # excluded regardless), and any trusted peer that misses the REKEY
+        # re-handshakes on its next undecryptable ciphertext via auto-KEYREQ —
+        # mirroring the Rust gate, whose REKEY NOTICEs are queued/retried
+        # rather than gating the send.
         try:
             fresh, had_pending = _get_or_generate_outgoing_key_with_rotation(context)
-            if had_pending:
-                _distribute_rekey(context, fresh, server)
+        except Exception as e:
+            _dbg(f"_e2e_gate_wire key generation failed for {context}: {e}")
+            return ("refuse", _REFUSE_ENCRYPT)
+        if had_pending:
+            _distribute_rekey_safe(context, fresh, server)
+        try:
             if is_action:
                 wires = _encrypt_ctcp_wire(fresh, context, body)
             else:
@@ -1995,7 +2029,13 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
         target, body = parsed
         # Re-entrancy guard: our own `_send_raw_privmsg` re-emits ciphertext
         # through this modifier — never re-process an already-encrypted line.
-        if body.startswith(WIRE_PREFIX):
+        # Key the guard on a STRUCTURALLY VALID wire chunk (parse_wire), NOT a
+        # bare `+RPE2E01` prefix: a user command like `/msg bob +RPE2E01 secret`
+        # starts with the prefix but is not a real chunk, and must still go
+        # through the gate (else it would leak as plaintext to an E2E DM). A
+        # crafted string that DOES parse as a chunk carries no readable
+        # plaintext, so passing it through is harmless.
+        if parse_wire(body) is not None:
             return msg
     except Exception as e:
         # A line we cannot even parse carries no derivable E2E context; the
@@ -2017,12 +2057,18 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
         return ""
     # action == "cipher": send the encrypted chunks ourselves and drop the
     # original. Once we have decided to encrypt we NEVER fall back to
-    # plaintext, even if a send raises mid-loop.
+    # plaintext, even if a send raises mid-loop — but the failure must be
+    # VISIBLE (never a silent message drop).
     try:
         for line in payload:
             _send_raw_privmsg(server, target, line)
     except Exception as e:
         _dbg(f"hook_irc_out_privmsg send EXCEPTION for {target}: {e}")
+        _prnt_err(
+            _target_buffer(server, target),
+            f"failed to send encrypted message to {target} — NOT delivered "
+            "(message stays encrypted; retry when the connection recovers)",
+        )
     return ""
 
 
@@ -2132,7 +2178,14 @@ def hook_input_text_for_buffer(data, modifier, modifier_data, text):
         if is_channel:
             channel = target
         else:
-            peer_handle = _resolve_handle_by_nick(server, target, target)
+            # Resolve the peer handle live OR from the keyring cache — the same
+            # resolution `/e2e on` / the outbound gate use (mirror of Rust
+            # `resolve_query_peer_handle`). Live-only resolution would miss the
+            # persisted `@<handle>` config whenever the peer isn't currently in
+            # a shared channel's nicklist, silently downgrading the DM to
+            # plaintext. If neither resolves, the out gate is still the
+            # authoritative backstop.
+            peer_handle = _resolve_handle_for_command(server, target, target)
             if peer_handle is None:
                 _prnt_err(buffer, f"cannot resolve handle for {target} — has the user spoken yet?")
                 return text
@@ -2146,16 +2199,9 @@ def hook_input_text_for_buffer(data, modifier, modifier_data, text):
             return text
         fresh, had_pending = _get_or_generate_outgoing_key_with_rotation(channel)
         if had_pending:
-            _distribute_rekey(channel, fresh)
-        sk = fresh
-        chunks = split_plaintext(plain)
-        total = len(chunks)
-        msgid = nacl_random(8)
-        ts = int(time.time())
-        for idx, chunk in enumerate(chunks, start=1):
-            aad = build_aad(channel, msgid, ts, idx, total)
-            nonce, ct = aead_encrypt(sk, aad, chunk)
-            wire = encode_wire(msgid, ts, idx, total, nonce, ct)
+            _distribute_rekey_safe(channel, fresh, server)
+        # Single source of truth for wire framing (shared with the out gate).
+        for wire in _encrypt_plain_wire(fresh, channel, plain):
             _send_raw_privmsg(server, target, wire)
         _prnt_self_msg(buffer, plain)
         return ""

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -2128,7 +2128,13 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         skew = abs(int(time.time()) - wire["ts"])
         if skew > TS_TOLERANCE:
             return ""
-        ctx = context_key(target, handle)
+        # STATUSMSG delivery (`@#chan`, `+#chan`): the decrypt context is the
+        # underlying channel, mirroring the outbound gate. Keep the original
+        # `target` for the reconstructed PRIVMSG line so weechat routes it
+        # unchanged; only the context key is stripped. Without this, ciphertext
+        # sent to `@#chan` would be keyed as a DM (`@<handle>`) and fail to
+        # decrypt (drop + spurious KEYREQ).
+        ctx = context_key(_strip_statusmsg(target), handle)
         with db_conn() as c:
             row = c.execute(
                 "SELECT sk, status FROM incoming WHERE handle = ? AND channel = ?",

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -1809,6 +1809,10 @@ _REFUSE_KEYRING = (
 _REFUSE_ENCRYPT = (
     "encryption failed — message NOT sent as plaintext (use /e2e off to send cleartext)"
 )
+_REFUSE_AMBIGUOUS = (
+    "ambiguous target %s — E2E is enabled on both %s "
+    "(STATUSMSG subset vs distinct channel); refusing to guess a context"
+)
 
 # `_config_enabled` result sentinels — explicit strings, never bare bools, so
 # a read error can NEVER be mistaken for "not enabled" (that would fail open).
@@ -1906,22 +1910,28 @@ def _distribute_rekey_safe(channel: str, new_sk: bytes, server: str) -> None:
         _dbg(f"_distribute_rekey_safe: distribution failed for {channel}: {e}")
 
 
-def _strip_statusmsg(target: str) -> str:
-    """Strip a leading STATUSMSG prefix (`@#chan`, `+#chan`, `%#chan`, …): a
-    message to a channel subset is still that channel for E2E. A real channel
-    name whose first char is itself a channel prefix is left untouched — only a
-    non-channel char sitting in front of a channel prefix is stripped. Without
-    this, `/msg @#secret …` classified as a DM to a bogus nick and leaked
-    plaintext to the channel ops on an E2E-enabled channel."""
-    i = 0
-    while (
-        i < len(target)
-        and target[i] in "@%+&~"
-        and i + 1 < len(target)
-        and target[i + 1] in CHANNEL_PREFIXES
-    ):
-        i += 1
-    return target[i:]
+def _channel_readings(target: str) -> list:
+    """Every channel reading of a possibly-STATUSMSG-prefixed target, most-
+    stripped first; empty list → not a channel. `@#chan` has exactly one
+    reading (#chan): a message to a channel subset is still that channel for
+    E2E, and without stripping, `/msg @#secret …` classified as a DM to a
+    bogus nick and leaked plaintext to the channel ops on an E2E-enabled
+    channel. But `+` and `&` are BOTH status prefixes AND channel prefixes
+    (RFC 2811), so `+#secret` is genuinely ambiguous without per-server
+    ISUPPORT: the voiced subset of #secret OR the distinct channel "+#secret".
+    Callers get every reading and must stay fail-closed across all of them —
+    encrypting under the one enabled reading is always safe (a peer on the
+    other reading sees undecryptable ciphertext, never plaintext). Mirrors the
+    Perl helper of the same name."""
+    run = 0
+    while run < len(target) and target[run] in "@%+&~":
+        run += 1
+    readings = []
+    for j in range(run, -1, -1):
+        rest = target[j:]
+        if rest and rest[0] in CHANNEL_PREFIXES:
+            readings.append(rest)
+    return readings
 
 
 def _e2e_gate_wire(server: str, target: str, body: str):
@@ -1937,10 +1947,12 @@ def _e2e_gate_wire(server: str, target: str, body: str):
     point it can be reached we can no longer rule out an enabled E2E context
     and must not leak plaintext."""
     try:
-        # STATUSMSG targets (`@#chan`, `+#chan`) address a channel subset —
-        # classify and key them by the underlying channel, never as a DM.
-        chan = _strip_statusmsg(target)
-        is_channel = bool(chan) and chan[0] in CHANNEL_PREFIXES
+        # STATUSMSG targets (`@#chan`) address a channel subset — classify and
+        # key them by the underlying channel, never as a DM. `+#chan`/`&#chan`
+        # are ambiguous (see _channel_readings): every reading is considered.
+        readings = _channel_readings(target)
+        is_channel = bool(readings)
+        chan = readings[0] if readings else target
 
         # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape
         # hatch, exactly as the Rust client leaves /ctcp and /version in
@@ -1961,7 +1973,7 @@ def _e2e_gate_wire(server: str, target: str, body: str):
             # (fail-closed visibility — never silently drop the warning on a
             # transient DB error).
             warn = None
-            if _config_enabled(chan) != _ENABLED_NO:
+            if any(_config_enabled(r) != _ENABLED_NO for r in readings):
                 warn = (
                     f"bot-style message to {chan} sent in CLEARTEXT — channel "
                     "lines starting with '.' or '!' bypass encryption for bots"
@@ -1970,7 +1982,17 @@ def _e2e_gate_wire(server: str, target: str, body: str):
 
         # Resolve the keyring context (unscoped in F1; F3 adds network scope).
         if is_channel:
-            context = chan
+            # Encrypt under whichever reading has E2E enabled — a peer on the
+            # other reading of an ambiguous target sees ciphertext, never
+            # plaintext. Two enabled readings cannot be disambiguated locally
+            # → refuse; a read error on ANY reading refuses too (fail-closed).
+            states = [(r, _config_enabled(r)) for r in readings]
+            if any(s == _ENABLED_ERR for _, s in states):
+                return ("refuse", _REFUSE_KEYRING)
+            on = [r for r, s in states if s == _ENABLED_YES]
+            if len(on) > 1:
+                return ("refuse", _REFUSE_AMBIGUOUS % (target, " and ".join(on)))
+            context = on[0] if on else chan
         else:
             # Live OR cached handle resolution (mirror of Rust
             # `resolve_query_peer_handle`): a peer who isn't currently in a
@@ -2128,18 +2150,34 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         skew = abs(int(time.time()) - wire["ts"])
         if skew > TS_TOLERANCE:
             return ""
-        # STATUSMSG delivery (`@#chan`, `+#chan`): the decrypt context is the
-        # underlying channel, mirroring the outbound gate. Keep the original
-        # `target` for the reconstructed PRIVMSG line so weechat routes it
-        # unchanged; only the context key is stripped. Without this, ciphertext
-        # sent to `@#chan` would be keyed as a DM (`@<handle>`) and fail to
-        # decrypt (drop + spurious KEYREQ).
-        ctx = context_key(_strip_statusmsg(target), handle)
+        # STATUSMSG delivery (`@#chan`): the decrypt context is the underlying
+        # channel, mirroring the outbound gate. Keep the original `target` for
+        # the reconstructed PRIVMSG line so weechat routes it unchanged; only
+        # the context key is re-read. Without this, ciphertext sent to `@#chan`
+        # would be keyed as a DM (`@<handle>`) and fail to decrypt (drop +
+        # spurious KEYREQ). An ambiguous `+#chan`/`&#chan` target has several
+        # readings: prefer one holding a trusted session for this sender (a
+        # wrong pick cannot leak — AEAD decrypt just fails); the most-stripped
+        # reading stays the default so auto-KEYREQ keeps keying off it.
+        readings = _channel_readings(target)
+        ctx_candidates = [context_key(r, handle) for r in readings] or [
+            context_key(target, handle)
+        ]
+        ctx = ctx_candidates[0]
         with db_conn() as c:
             row = c.execute(
                 "SELECT sk, status FROM incoming WHERE handle = ? AND channel = ?",
                 (handle, ctx),
             ).fetchone()
+            if row is None or row[1] != "trusted":
+                for cand in ctx_candidates[1:]:
+                    alt = c.execute(
+                        "SELECT sk, status FROM incoming WHERE handle = ? AND channel = ?",
+                        (handle, cand),
+                    ).fetchone()
+                    if alt is not None and alt[1] == "trusted":
+                        ctx, row = cand, alt
+                        break
         if row is None or row[1] != "trusted":
             _dbg(
                 f"hook_irc_in_privmsg: no trusted incoming for ({handle},{ctx}) "

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -401,6 +401,16 @@ def db_conn():
     conn = sqlite3.connect(DB_PATH)
     try:
         yield conn
+        # Persist on success. sqlite3 opens an implicit transaction for every
+        # INSERT/UPDATE/DELETE in legacy isolation mode; without this commit the
+        # transaction is rolled back on close() and NOTHING is written — which
+        # would leave `/e2e on`, session keys, and peer trust un-persisted and
+        # silently downgrade every "enabled" conversation to plaintext (the gate
+        # would always read "not enabled"). Commit-on-success / rollback-on-error.
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     finally:
         conn.close()
 

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -1721,6 +1721,15 @@ def encode_wire(
 
 
 def split_plaintext(pt: str) -> list[bytes]:
+    return split_plaintext_budget(pt, MAX_PT_PER_CHUNK)
+
+
+def split_plaintext_budget(pt: str, max_per_chunk: int) -> list[bytes]:
+    """`split_plaintext` with a caller-chosen per-chunk byte budget — mirrors
+    Rust `src/e2e/chunker.rs::split_plaintext_budget`. Used by the CTCP ACTION
+    splitter, whose per-piece budget must leave room for the `\x01ACTION …\x01`
+    framing each piece is wrapped in afterwards. The `MAX_CHUNKS` cap applies to
+    the produced pieces regardless of budget."""
     # G13: refuse empty plaintext outright — mirrors Rust
     # `src/e2e/chunker.rs::split_plaintext`. No zero-length-ciphertext
     # chunk should ever be shipped to a peer.
@@ -1730,7 +1739,7 @@ def split_plaintext(pt: str) -> list[bytes]:
     chunks: list[bytes] = []
     i = 0
     while i < len(b):
-        j = min(i + MAX_PT_PER_CHUNK, len(b))
+        j = min(i + max_per_chunk, len(b))
         while j > i and j < len(b) and (b[j] & 0xC0) == 0x80:
             j -= 1
         if j == i:
@@ -1771,6 +1780,250 @@ def _get_or_generate_outgoing_key_with_rotation(channel: str) -> tuple[bytes, bo
             (channel, fresh, int(time.time())),
         )
         return fresh, had_pending
+
+
+# ── Outbound E2E gate (F1) ──────────────────────────────────────────────
+#
+# Mirror of the Rust client's single fail-closed chokepoint
+# (`src/app/e2e_gate.rs::e2e_encrypt_or_passthrough`). In the Rust client
+# EVERY send path routes through that one gate. WeeChat has no equivalent
+# high-level chokepoint, so we hook the low-level `irc_out1_privmsg` modifier:
+# every PRIVMSG that reaches the wire — from plain input, `/msg`, `/say`,
+# `/me` (ACTION), `/amsg`, … — passes through here regardless of the command
+# that produced it. Without this, `/me`/`/msg`/`/say` bypassed
+# `hook_input_text_for_buffer` (which bails on any `/`-command) and left an
+# E2E conversation in PLAINTEXT.
+#
+# The gate NEVER downgrades an E2E-enabled conversation to plaintext: an
+# unresolved handle, a keyring read error, or an encrypt failure all REFUSE
+# (drop the line + show a visible `[E2E]` reason), exactly like the Rust
+# `E2eRefusal` variants.
+
+# Themed refusal lines (mirror `E2eRefusal::user_message`).
+_REFUSE_NO_HANDLE = (
+    "cannot encrypt PM without peer handle — wait for a message from them first"
+)
+_REFUSE_KEYRING = (
+    "cannot encrypt — keyring read failed; message NOT sent (E2E stays on)"
+)
+_REFUSE_ENCRYPT = (
+    "encryption failed — message NOT sent as plaintext (use /e2e off to send cleartext)"
+)
+
+# `_config_enabled` result sentinels — explicit strings, never bare bools, so
+# a read error can NEVER be mistaken for "not enabled" (that would fail open).
+_ENABLED_YES = "yes"
+_ENABLED_NO = "no"
+_ENABLED_ERR = "err"
+
+
+def _config_enabled(context: str) -> str:
+    """Fail-closed enabled check: `_ENABLED_YES` / `_ENABLED_NO` / `_ENABLED_ERR`.
+    A DB read error returns `_ENABLED_ERR` so the caller refuses rather than
+    risk plaintext — mirrors the Rust gate's `KeyringRead` refusal."""
+    try:
+        with db_conn() as c:
+            row = c.execute(
+                "SELECT enabled FROM channels WHERE channel = ?", (context,)
+            ).fetchone()
+        return _ENABLED_YES if (row is not None and row[0]) else _ENABLED_NO
+    except Exception as e:
+        _dbg(f"_config_enabled read error for {context}: {e}")
+        return _ENABLED_ERR
+
+
+def _parse_out_privmsg(raw: str) -> tuple[str, str] | None:
+    """Parse an `irc_out1_privmsg` line into `(target, body)`. Returns None if
+    it is not a PRIVMSG we recognize (then the caller passes it through)."""
+    s = raw
+    if s.startswith("@"):  # strip IRCv3 message tags
+        sp = s.find(" ")
+        if sp == -1:
+            return None
+        s = s[sp + 1 :]
+    if s.startswith(":"):  # strip an (unusual for client→server) source prefix
+        sp = s.find(" ")
+        if sp == -1:
+            return None
+        s = s[sp + 1 :]
+    parts = s.split(" ", 2)
+    if len(parts) < 3 or parts[0].upper() != "PRIVMSG":
+        return None
+    target = parts[1]
+    body = parts[2]
+    if body.startswith(":"):
+        body = body[1:]
+    return (target, body)
+
+
+def _encrypt_plain_wire(sk: bytes, context: str, plain: str) -> list[str]:
+    """Encrypt `plain` under session key `sk` for `context`, one wire line per
+    chunk. `context` is the wire context used for the AAD (unscoped in F1)."""
+    chunks = split_plaintext(plain)
+    total = len(chunks)
+    msgid = nacl_random(8)
+    ts = int(time.time())
+    out: list[str] = []
+    for idx, chunk in enumerate(chunks, start=1):
+        aad = build_aad(context, msgid, ts, idx, total)
+        nonce, ct = aead_encrypt(sk, aad, chunk)
+        out.append(encode_wire(msgid, ts, idx, total, nonce, ct))
+    return out
+
+
+def _encrypt_ctcp_wire(sk: bytes, context: str, frame: str) -> list[str]:
+    """Encrypt a `\x01ACTION …\x01` CTCP frame — mirror of Rust
+    `E2eManager::encrypt_outgoing_ctcp`. A frame fitting one chunk encrypts
+    as-is; a longer ACTION splits into independent, individually-wrapped
+    `\x01ACTION piece\x01` frames (never fragmenting the CTCP envelope across
+    bare chunks). Byte length, not char length, gates the one-chunk case."""
+    action_prefix = "\x01ACTION "
+    action_framing = len(action_prefix) + 1  # +1 for the trailing \x01
+    if len(frame.encode("utf-8")) <= MAX_PT_PER_CHUNK:
+        return _encrypt_plain_wire(sk, context, frame)
+    if not (frame.startswith(action_prefix) and frame.endswith("\x01")):
+        raise ValueError("CTCP frame exceeds one encrypted chunk and cannot be split")
+    body = frame[len(action_prefix) : -1]
+    budget = MAX_PT_PER_CHUNK - action_framing
+    pieces = split_plaintext_budget(body, budget)
+    out: list[str] = []
+    for piece in pieces:
+        piece_str = piece.decode("utf-8")
+        out.extend(_encrypt_plain_wire(sk, context, f"{action_prefix}{piece_str}\x01"))
+    return out
+
+
+def _e2e_gate_wire(server: str, target: str, body: str):
+    """Fail-closed outbound gate — mirror of `e2e_encrypt_or_passthrough`.
+
+    Returns one of:
+      ("pass", None)          — send `body` unchanged (no E2E state / bypass)
+      ("cipher", [wire, …])   — send these encrypted lines, drop the original
+      ("refuse", themed_msg)  — drop; caller shows the `[E2E]` reason
+      ("bypass", warn_or_None)— channel bot bypass; send plaintext, maybe warn
+
+    Never raises: any unexpected error resolves to a refusal, because at the
+    point it can be reached we can no longer rule out an enabled E2E context
+    and must not leak plaintext."""
+    try:
+        is_channel = bool(target) and target[0] in CHANNEL_PREFIXES
+
+        # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape
+        # hatch, exactly as the Rust client leaves /ctcp and /version in
+        # cleartext. Only ACTION frames and plain text are encrypted.
+        is_ctcp = len(body) >= 2 and body.startswith("\x01") and body.endswith("\x01")
+        is_action = body.startswith("\x01ACTION ") and body.endswith("\x01")
+        if is_ctcp and not is_action:
+            return ("pass", None)
+
+        # Bot-command bypass: `.cmd`/`!cmd` go out unencrypted so channel bots
+        # can parse them. CHANNEL-ONLY and SINGLE-LINE (a newline forces the
+        # full gate); DMs never bypass. Mirror of the channel-only bypass +
+        # `warn_e2e_bot_bypass` visibility in the Rust gate.
+        if is_channel and (body.startswith(".") or body.startswith("!")) and "\n" not in body:
+            warn = None
+            if _config_enabled(target) == _ENABLED_YES:
+                warn = (
+                    f"bot-style message to {target} sent in CLEARTEXT — channel "
+                    "lines starting with '.' or '!' bypass encryption for bots"
+                )
+            return ("bypass", warn)
+
+        # Resolve the keyring context (unscoped in F1; F3 adds network scope).
+        if is_channel:
+            context = target
+        else:
+            handle = _resolve_handle_by_nick(server, target, target)
+            if handle is None:
+                # No resolvable handle → no `@<handle>` config can exist.
+                # Refuse only if an enabled legacy bare-nick row exists;
+                # otherwise plaintext passthrough is safe (no E2E state).
+                legacy = _config_enabled(target)
+                if legacy == _ENABLED_ERR:
+                    return ("refuse", _REFUSE_KEYRING)
+                if legacy == _ENABLED_YES:
+                    return ("refuse", _REFUSE_NO_HANDLE)
+                return ("pass", None)
+            context = "@" + handle
+
+        enabled = _config_enabled(context)
+        if enabled == _ENABLED_ERR:
+            return ("refuse", _REFUSE_KEYRING)
+        if enabled == _ENABLED_NO:
+            return ("pass", None)
+
+        # Enabled — encrypt. An encrypt failure REFUSES (never plaintext).
+        try:
+            fresh, had_pending = _get_or_generate_outgoing_key_with_rotation(context)
+            if had_pending:
+                _distribute_rekey(context, fresh, server)
+            if is_action:
+                wires = _encrypt_ctcp_wire(fresh, context, body)
+            else:
+                wires = _encrypt_plain_wire(fresh, context, body)
+        except Exception as e:
+            _dbg(f"_e2e_gate_wire encrypt failed for {context}: {e}")
+            return ("refuse", _REFUSE_ENCRYPT)
+        return ("cipher", wires)
+    except Exception as e:
+        _dbg(f"_e2e_gate_wire OUTER EXCEPTION for {target}: {e}\n{traceback.format_exc()}")
+        # We touched keyring state but failed before ruling E2E out — refuse
+        # rather than risk plaintext (fail-closed).
+        return ("refuse", _REFUSE_KEYRING)
+
+
+def _target_buffer(server: str, target: str) -> str:
+    """Best-effort buffer pointer for showing an `[E2E]` line about `target`."""
+    if weechat is None:
+        return ""
+    buf = weechat.buffer_search("irc", f"{server}.{target}") or ""
+    if not buf:
+        buf = weechat.buffer_search("irc", f"server.{server}") or ""
+    return buf
+
+
+def hook_irc_out_privmsg(data, modifier, server, msg):
+    """`irc_out1_privmsg` modifier — the authoritative fail-closed outbound
+    gate. Returns the (possibly unchanged) line, or "" to drop it after having
+    sent encrypted chunks / refused."""
+    try:
+        if weechat is None:
+            return msg
+        parsed = _parse_out_privmsg(msg)
+        if parsed is None:
+            return msg
+        target, body = parsed
+        # Re-entrancy guard: our own `_send_raw_privmsg` re-emits ciphertext
+        # through this modifier — never re-process an already-encrypted line.
+        if body.startswith(WIRE_PREFIX):
+            return msg
+    except Exception as e:
+        # A line we cannot even parse carries no derivable E2E context; the
+        # irc_out1_privmsg feed is always a PRIVMSG, so this is unreachable in
+        # practice. Passing it through cannot leak an E2E conversation.
+        _dbg(f"hook_irc_out_privmsg parse EXCEPTION: {e}")
+        return msg
+
+    action, payload = _e2e_gate_wire(server, target, body)
+    if action == "pass":
+        return msg
+    if action == "bypass":
+        if payload:
+            _prnt_warn(_target_buffer(server, target), payload)
+        return msg
+    if action == "refuse":
+        _prnt_err(_target_buffer(server, target), payload)
+        _dbg(f"hook_irc_out_privmsg REFUSED send to {target}: {payload}")
+        return ""
+    # action == "cipher": send the encrypted chunks ourselves and drop the
+    # original. Once we have decided to encrypt we NEVER fall back to
+    # plaintext, even if a send raises mid-loop.
+    try:
+        for line in payload:
+            _send_raw_privmsg(server, target, line)
+    except Exception as e:
+        _dbg(f"hook_irc_out_privmsg send EXCEPTION for {target}: {e}")
+    return ""
 
 
 def hook_irc_in_privmsg(data, modifier, server, msg):
@@ -2601,6 +2854,9 @@ def main() -> None:
     weechat.hook_modifier("irc_in2_privmsg", "hook_irc_in_privmsg", "")
     weechat.hook_modifier("input_text_for_buffer", "hook_input_text_for_buffer", "")
     weechat.hook_modifier("irc_in2_notice", "hook_irc_in_notice", "")
+    # Authoritative outbound fail-closed gate (F1): every PRIVMSG on the wire —
+    # `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
+    weechat.hook_modifier("irc_out1_privmsg", "hook_irc_out_privmsg", "")
     weechat.hook_command(
         "e2e",
         SCRIPT_DESC,

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -1906,6 +1906,24 @@ def _distribute_rekey_safe(channel: str, new_sk: bytes, server: str) -> None:
         _dbg(f"_distribute_rekey_safe: distribution failed for {channel}: {e}")
 
 
+def _strip_statusmsg(target: str) -> str:
+    """Strip a leading STATUSMSG prefix (`@#chan`, `+#chan`, `%#chan`, …): a
+    message to a channel subset is still that channel for E2E. A real channel
+    name whose first char is itself a channel prefix is left untouched — only a
+    non-channel char sitting in front of a channel prefix is stripped. Without
+    this, `/msg @#secret …` classified as a DM to a bogus nick and leaked
+    plaintext to the channel ops on an E2E-enabled channel."""
+    i = 0
+    while (
+        i < len(target)
+        and target[i] in "@%+&~"
+        and i + 1 < len(target)
+        and target[i + 1] in CHANNEL_PREFIXES
+    ):
+        i += 1
+    return target[i:]
+
+
 def _e2e_gate_wire(server: str, target: str, body: str):
     """Fail-closed outbound gate — mirror of `e2e_encrypt_or_passthrough`.
 
@@ -1919,7 +1937,10 @@ def _e2e_gate_wire(server: str, target: str, body: str):
     point it can be reached we can no longer rule out an enabled E2E context
     and must not leak plaintext."""
     try:
-        is_channel = bool(target) and target[0] in CHANNEL_PREFIXES
+        # STATUSMSG targets (`@#chan`, `+#chan`) address a channel subset —
+        # classify and key them by the underlying channel, never as a DM.
+        chan = _strip_statusmsg(target)
+        is_channel = bool(chan) and chan[0] in CHANNEL_PREFIXES
 
         # Non-ACTION CTCP (VERSION, PING, …) is a deliberate plaintext escape
         # hatch, exactly as the Rust client leaves /ctcp and /version in
@@ -1940,16 +1961,16 @@ def _e2e_gate_wire(server: str, target: str, body: str):
             # (fail-closed visibility — never silently drop the warning on a
             # transient DB error).
             warn = None
-            if _config_enabled(target) != _ENABLED_NO:
+            if _config_enabled(chan) != _ENABLED_NO:
                 warn = (
-                    f"bot-style message to {target} sent in CLEARTEXT — channel "
+                    f"bot-style message to {chan} sent in CLEARTEXT — channel "
                     "lines starting with '.' or '!' bypass encryption for bots"
                 )
             return ("bypass", warn)
 
         # Resolve the keyring context (unscoped in F1; F3 adds network scope).
         if is_channel:
-            context = target
+            context = chan
         else:
             # Live OR cached handle resolution (mirror of Rust
             # `resolve_query_peer_handle`): a peer who isn't currently in a
@@ -2052,7 +2073,12 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
             _prnt_warn(_target_buffer(server, target), payload)
         return msg
     if action == "refuse":
-        _prnt_err(_target_buffer(server, target), payload)
+        # For command paths (/msg, /me, /say) weechat's core may already have
+        # echoed the plaintext locally, so make the drop explicit.
+        _prnt_err(
+            _target_buffer(server, target),
+            f"{payload} — the message shown above was NOT delivered",
+        )
         _dbg(f"hook_irc_out_privmsg REFUSED send to {target}: {payload}")
         return ""
     # action == "cipher": send the encrypted chunks ourselves and drop the
@@ -2143,6 +2169,15 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
             pt_str = pt.decode("utf-8")
         except UnicodeDecodeError:
             pt_str = pt.decode("utf-8", errors="replace")
+        # A decrypted non-ACTION CTCP frame (\x01VERSION\x01, \x01PING\x01, …)
+        # must NOT be re-injected into weechat's PRIVMSG pipeline: weechat would
+        # interpret it and auto-answer with a PLAINTEXT NOTICE. Our own outbound
+        # side never encrypts non-ACTION CTCP (it is a cleartext escape hatch),
+        # so this is anomalous — drop it. ACTION frames and ordinary text pass
+        # through and render normally.
+        if pt_str.startswith("\x01") and not pt_str.startswith("\x01ACTION "):
+            _dbg(f"hook_irc_in_privmsg: dropping decrypted non-ACTION CTCP from {nick}")
+            return ""
         return f":{prefix} PRIVMSG {target} :{pt_str}"
     except Exception as e:
         _dbg(f"hook_irc_in_privmsg OUTER EXCEPTION: {e}\n{traceback.format_exc()}")


### PR DESCRIPTION
## Summary

Aligns the RPE2E companion scripts (`scripts/weechat/rpe2e.py`,
`scripts/irssi/rpe2e.pl`) with the Rust client's E2E gate semantics. The
overriding rule throughout is **fail-closed**: if E2E is enabled for a
conversation the scripts never put plaintext on the wire and never render raw
ciphertext; every refusal is visible.

Findings addressed (from a prior adversarial audit): **F1** (both scripts
leaked `/me`, `/msg`, `/say` as plaintext) and **F2** (irssi mis-rendered
incoming encrypted ACTIONs). **F3** (per-network scoping) is **deferred** to a
focused follow-up — see below.

## What changed

### F1 — single fail-closed outbound gate (both scripts)
The only outbound gate bailed on any `/`-command, so `/me` (ACTION), `/msg`,
`/say`, `/amsg` reached the wire as plaintext in an E2E conversation. Both
scripts now route **every** outgoing PRIVMSG through one low-level chokepoint,
mirroring the Rust single gate (`src/app/e2e_gate.rs::e2e_encrypt_or_passthrough`):

- weechat: `irc_out1_privmsg` modifier (keeps the input-text hook for plain-line
  echo; its ciphertext passes the gate's re-entrancy guard).
- irssi: `server sending command` signal — now the **sole** outbound gate
  (`signal_send_text` removed; irssi's command layer produces the local echo).

Both gates:
- re-entrancy guard keyed on a **structurally valid** wire chunk (`parse_wire`),
  not a bare `+RPE2E01` prefix, so `/msg bob +RPE2E01 secret` can't leak;
- channel-only, single-line `.`/`!` bot bypass with a visible CLEARTEXT warning
  when E2E can't be positively ruled out;
- DM handle resolved **live or from cache** (a renamed peer still keys to its
  config); unresolved+enabled → refuse; keyring/DB read error → refuse; encrypt
  failure → refuse — never plaintext, always visible;
- CTCP **ACTION frame splitter** (`encrypt_outgoing_ctcp` mirror): a long `/me`
  splits into complete `\x01ACTION …\x01` frames, never fragmenting the CTCP
  envelope;
- non-ACTION CTCP stays plaintext (matching the Rust `/ctcp`/`/version` escape
  hatch);
- **STATUSMSG** targets (`@#chan`, `+#chan`) keyed by the underlying channel, so
  `/msg @#secret …` on an E2E channel encrypts instead of leaking to ops.

### F2 — irssi decrypts before the CTCP split
Decryption moved from `message public`/`private` (post-CTCP-split) to the
`event privmsg` signal (the analog of weechat's `irc_in2_privmsg`), so a
recovered `\x01ACTION…\x01` renders as a proper action instead of raw control
characters. Decrypted **non-ACTION** CTCP is dropped rather than re-driven (it
would otherwise be auto-answered in plaintext) — same guard added to weechat's
incoming path for parity.

### Pre-existing fix: weechat DB writes never committed
`db_conn()` opened SQLite in legacy isolation mode and only `close()`d — no
`commit()` anywhere — so `/e2e on`, session keys, and peer trust were rolled
back and **never persisted**, which would make the gate always read
"not enabled" and silently send plaintext. Fixed (commit-on-success /
rollback-on-error). Found while wiring the F1 gate.

## Review

Each phase went through a high-effort multi-agent code review; all confirmed
findings were fixed and re-verified:
- weechat F1: 6 findings (DM cache-fallback, `parse_wire` guard, best-effort
  rekey, visible send-failure, bot-bypass warn on DB error, DRY).
- irssi F1/F2: 7 findings (live+cache DM resolution, STATUSMSG, refuse-after-
  echo wording, non-ACTION CTCP drop, remove `signal_send_text` duplication,
  conditional keyring save, double-parse) + a weechat consistency sweep.

## Testing

`python3 -m py_compile` and `perl -c` (stubbed `Irssi`) both clean. Headless
harnesses exercise the parser, CTCP split+reassembly, and every gate decision
(pass / cipher / bypass / refuse; DM cache & live resolution; STATUSMSG;
incoming ACTION/normal/CTCP handling). A **Perl-encrypt → Python-decrypt interop
test** confirms the two scripts share a byte-identical wire format (plain UTF-8
and a 3-way ACTION split). No live two-peer server test was run.

## F3 deferred (per-network context scoping)
F3 is interop-critical and has a genuine migration sharp-edge: the scripts lack
the "configured-networks" tracking Rust uses (`legacy_adoption_allowed`) to make
scoping safe, so a rushed version risks a fail-open downgrade-after-upgrade or a
cross-network key leak — both worse than the LOW-MED issue it fixes. Design +
full change-surface map + hazards are captured in
`docs/superpowers/specs/2026-07-09-rpe2e-f3-network-scoping-followup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add fail-closed outbound E2E gate and fix CTCP ACTION encryption in WeeChat and irssi companion scripts
> - Adds `hook_irc_out1_privmsg` (WeeChat) and `signal_server_outgoing` (irssi) as authoritative outbound gates that intercept every PRIVMSG at the raw-line level, encrypt it, or visibly refuse — plaintext is never sent for E2E-enabled contexts.
> - Adds `_encrypt_ctcp_wire` to correctly split and encrypt long `/me` (CTCP ACTION) messages without fragmenting CTCP framing across chunks.
> - Adds `_channel_readings` and STATUSMSG handling so ambiguous targets like `+#chan` or `&#chan` decrypt under the correct trusted session context.
> - Adds pre-CTCP-split decrypt in irssi via `event privmsg` so encrypted ACTIONs render as proper actions; encrypted non-ACTION CTCP frames are dropped in both clients to prevent plaintext auto-replies.
> - Fixes `db_conn` in [rpe2e.py](https://github.com/outragedevs/repartee/pull/30/files#diff-7a10381b6b240b56c951a781a4bae33819af169405d81189bbacf71007a9e591) to commit on normal exit and roll back on exception, ensuring SQLite keyring writes (key storage, E2E enablement) persist reliably.
> - Risk: irssi now refuses to load on versions below 1.4.1 (ABI date < 20220612) since the `server outgoing modify` signal is required for the gate.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ed5fe54.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->