### PR TITLE
fix(e2e): recipient-keyed DM context in the companion scripts (DM addendum port)

### DIFF
--- a/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
@@ -31,25 +31,30 @@ had no DM enable path (`/e2e on|off|mode` were channel-only).
   negotiate the wrong direction). Next message re-establishes after the handle
   is learned. Own handle resets at registration and re-seeds.
 
-## Own-handle capture (mirrors Rust, with ranked sources)
+## Own-handle capture (prefix-visible sources ONLY)
 
-Post-PR review round (2026-07-10): sources are RANKED, because they disagree
-on cloaked networks — what matters is the handle as PEERS see it (our message
-prefix), and solanum-family ircds (Libera) answer a self-USERHOST with the
-REAL host, not the cloak (verified in solanum `m_userhost.c`: `target ==
-source` uses `sockhost`/`orighost`). Rank 2 (authoritative, prefix-visible):
+Final design (review rounds 2026-07-10/11 collapsed an interim ranked-source
+scheme): the store only ever holds values PEERS themselves see in our message
+prefix — anything else eventually disagrees with it and breaks the
+recipient-keyed context. Sources, all equal-trust (newest write wins):
 echo-message echoes (weechat), our own JOIN, our own CHGHOST, RPL_HOSTHIDDEN
-(396). Rank 1 (seed of last resort): the 302 reply. A lower rank never
-overwrites a higher one; reads prefer the rank-2 store, then a live
-own-nicklist lookup (both clients keep nicklists current, incl. CHGHOST),
-then (irssi) core's join/396-seeded `$server->{userhost}`, then rank 1.
-The load-time self-USERHOST is sent UNCONDITIONALLY for connected servers
-(a mere non-empty fallback can be stale — irssi core does not update
-`userhost` on own CHGHOST); under the ranking this can never clobber a
-prefix-visible value. Review claim that weechat's `irc_server_connected` is
-a socket-connect signal was refuted against weechat source: it is emitted in
-`IRC_PROTOCOL_CALLBACK(001)` (irc-protocol.c), i.e. exactly at the welcome
-numeric, same as the Rust client's one-shot.
+(396), self-WHOIS RPL_WHOISUSER (311), and a live own-nicklist lookup
+(promoted into the store on discovery, because nicklists vanish with the
+last part). The one-shot at registration/load is a self-WHOIS, not a
+self-USERHOST: solanum-family ircds (Libera) answer a self-USERHOST with the
+REAL host (`m_userhost.c`: `target == source` uses `sockhost`/`orighost`),
+while 311 carries the DISPLAYED host by definition (`m_whois.c` uses
+`target_p->host`; the real host travels only in 338, never parsed). There is
+deliberately NO weaker fallback tier: irssi core's `$server->{userhost}` is
+not updated on our own CHGHOST (stale risk) and USERHOST is self-view — with
+both removed, "unknown" is a transient one-round-trip state (held wires +
+visible notice), after which every source in play equals the prefix.
+Historical notes: the claim that weechat's `irc_server_connected` fires at
+socket-connect was refuted against weechat source (it is emitted in
+`IRC_PROTOCOL_CALLBACK(001)`, the welcome numeric); weechat's `irc_in2_*`
+modifiers retain IRCv3 tags, so every hook parses through
+`_split_irc_tags()` and the decrypted PRIVMSG reconstruction re-prepends the
+original tag section.
 
 Per-server volatile store (never persisted):
 

--- a/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
@@ -31,7 +31,25 @@ had no DM enable path (`/e2e on|off|mode` were channel-only).
   negotiate the wrong direction). Next message re-establishes after the handle
   is learned. Own handle resets at registration and re-seeds.
 
-## Own-handle capture (mirrors Rust)
+## Own-handle capture (mirrors Rust, with ranked sources)
+
+Post-PR review round (2026-07-10): sources are RANKED, because they disagree
+on cloaked networks — what matters is the handle as PEERS see it (our message
+prefix), and solanum-family ircds (Libera) answer a self-USERHOST with the
+REAL host, not the cloak (verified in solanum `m_userhost.c`: `target ==
+source` uses `sockhost`/`orighost`). Rank 2 (authoritative, prefix-visible):
+echo-message echoes (weechat), our own JOIN, our own CHGHOST, RPL_HOSTHIDDEN
+(396). Rank 1 (seed of last resort): the 302 reply. A lower rank never
+overwrites a higher one; reads prefer the rank-2 store, then a live
+own-nicklist lookup (both clients keep nicklists current, incl. CHGHOST),
+then (irssi) core's join/396-seeded `$server->{userhost}`, then rank 1.
+The load-time self-USERHOST is sent UNCONDITIONALLY for connected servers
+(a mere non-empty fallback can be stale — irssi core does not update
+`userhost` on own CHGHOST); under the ranking this can never clobber a
+prefix-visible value. Review claim that weechat's `irc_server_connected` is
+a socket-connect signal was refuted against weechat source: it is emitted in
+`IRC_PROTOCOL_CALLBACK(001)` (irc-protocol.c), i.e. exactly at the welcome
+numeric, same as the Rust client's one-shot.
 
 Per-server volatile store (never persisted):
 

--- a/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
+++ b/docs/superpowers/specs/2026-07-09-rpe2e-dm-addendum-port.md
@@ -1,0 +1,108 @@
+# RPE2E companion scripts — port the recipient-keyed DM addendum
+
+**Date:** 2026-07-09
+**Branch:** `fix/rpe2e-dm-addendum`
+**Scope:** `scripts/weechat/rpe2e.py`, `scripts/irssi/rpe2e.pl`
+**Protocol spec (normative):** `docs/rpe2e-dm-addendum.md`
+**Rust reference:** `src/irc/events.rs` (`incoming_e2e_context`, `set_own_handle`,
+`handle_userhost_reply`/`parse_userhost_reply`), `src/app/irc.rs` (one-shot
+self-USERHOST at RPL_WELCOME + own-handle reset), `src/commands/handlers_e2e.rs`
+(`current_e2e_own_context` command split), `src/e2e/wire.rs`
+(`build_aad_golden_vector_dm`).
+
+## Problem
+
+The scripts predate the recipient-keyed DM agreement (June 2026, repartee +
+lurker): inbound DM decrypt and auto-KEYREQ key the context off the **sender's**
+handle, and there is no own-handle concept at all. Against current repartee:
+repartee→script DMs never authenticate (AAD `@<recipient>` vs recomputed
+`@<sender>`), script↔script DMs fail both ways. The irssi script additionally
+had no DM enable path (`/e2e on|off|mode` were channel-only).
+
+## The rule being ported
+
+- DM context = `@<recipient_handle>`. Encrypt → `@<peer>` (unchanged);
+  decrypt → `@<own>` (changed).
+- KEYREQ is sent by the party that wants to RECEIVE and stamps `c=@<own_handle>`;
+  the responder echoes `c=` verbatim (both scripts already echo verbatim — the
+  seam is only in what we stamp and what we look up).
+- While our own handle is unknown: inbound DM ciphertext is dropped with a
+  notice — never keyed by the sender's handle, never auto-KEYREQ'd (that would
+  negotiate the wrong direction). Next message re-establishes after the handle
+  is learned. Own handle resets at registration and re-seeds.
+
+## Own-handle capture (mirrors Rust)
+
+Per-server volatile store (never persisted):
+
+- **weechat**: module dict `_own_handle[server]`.
+  - `irc_server_connected` signal → reset + one-shot `/quote USERHOST <nick>`
+    (gated to the connect event, never per message — the 302 reply is itself a
+    message and would loop).
+  - `irc_in2_302` modifier → parse `nick[*]=[+|-]ident@host` entries (same
+    normalization as Rust `parse_userhost_reply`: strip oper `*`, strip away
+    `+`/`-`), match own nick case-insensitively, seed the store. Pass the line
+    through unmodified.
+  - `irc_in2_chghost` modifier → own nick → update store.
+  - echo-message: own-nick prefix in `irc_in2_privmsg` seeds the store, and an
+    own `+RPE2E01` echo is swallowed (weechat requests all caps by default, so
+    echo-message is commonly active; without swallowing, our own ciphertext echo
+    would be treated as a peer's → decrypt fail → KEYREQ to ourselves).
+  - `irc_server_disconnected` → reset.
+  - Script load while already connected: iterate connected servers, send the
+    one-shot USERHOST (no 001 will fire for them).
+- **irssi**: `%own_handle` keyed by `$server->{tag}` + `_own_handle($server)`
+  accessor falling back to `$server->{userhost}` (irssi core seeds that from our
+  first own-JOIN and updates it on 396, but NOT on own CHGHOST and not before
+  the first join — hence the script-side store on top).
+  - `event 001` → reset tag + one-shot `USERHOST <nick>` (raw).
+  - `event 302` → parse (same normalization), match `$server->{nick}`, seed.
+  - `event chghost` → own nick → update.
+  - Load-time: for already-connected servers without a known handle, send the
+    one-shot USERHOST.
+
+## Context seams changed
+
+Inbound (both scripts):
+- PRIVMSG wire decrypt, DM case: ctx `@<own_handle>`; unknown → drop the wire
+  (fail-closed, throttled notice), NO auto-KEYREQ.
+- auto-KEYREQ (DM): `c=@<own_handle>`; the config-enabled gate stays keyed by
+  the PEER (`@<sender_handle>`) — config describes "E2E with that peer", the
+  wire context names the direction's recipient. (weechat's auto-KEYREQ has no
+  config gate by design — trigger is undecryptable ciphertext; unchanged.)
+- KEYRSP/REKEY handlers: no change — they already install under the verbatim
+  wire `c=`, which now arrives as `@<own>` for sessions we requested.
+- Reciprocal KEYREQ (serve/accept paths): stamped `@<own>` for DMs instead of
+  echoing the requester's context (which named the wrong direction). Rust has a
+  known benign residual here (`@<peer>`); the scripts stamp correctly — wire-
+  compatible either way since responders serve `c=` verbatim.
+
+Commands:
+- Unchanged (peer-keyed stores): on/off/mode (config), accept/decline
+  (pending_inbound is keyed by the requester's own-stamped `c=` = `@<peer>` as
+  we see them), rotate/outgoing/outgoing_recipients, reverify (handle-only).
+- Changed (real incoming DM sessions now live under `@<own>`): verify reads
+  `(peer_handle, @<own>)`; revoke/unrevoke/forget touch BOTH `@<own>` (real
+  sessions) and `@<peer>` (KEYREQ-direction trust markers); list in a query
+  filters by peer handle instead of ctx.
+- handshake (DM): enabled check stays `@<peer>`; the KEYREQ stamps `c=@<own>`
+  (refused with a clear message while the own handle is unknown).
+- irssi `/e2e on|off|mode` extended to query buffers (peer-keyed config),
+  matching weechat and the Rust client.
+
+## Migration
+
+None needed: old sender-keyed incoming DM rows simply never match again and the
+transport self-heals via session miss → auto-KEYREQ → fresh handshake under the
+correct context (the addendum's volatile-handle path). Old DM configs
+(`@<peer>`) remain valid as-is.
+
+## Verification
+
+- Golden DM AAD vector from `src/e2e/wire.rs::build_aad_golden_vector_dm`
+  asserted byte-for-byte against both scripts' `build_aad`.
+- Behavioral harnesses (stubbed weechat/Irssi + NaCl): 302/CHGHOST/echo
+  own-handle capture incl. normalization, DM decrypt ctx selection, unknown-own
+  drop with no KEYREQ, auto-KEYREQ `c=` stamping, command-path ctx routing,
+  channel paths unchanged.
+- `python3 -m py_compile` + `perl -c` (stubbed runtime modules).

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -581,7 +581,16 @@ sub _own_handle_for {
     if (length $nick) {
         for my $ch (eval { $server->channels() }) {
             my $n = eval { $ch->nick_find($nick) };
-            return $n->{host} if $n && $n->{host};
+            next unless $n && $n->{host};
+            # PROMOTE to the rank-2 store: nicklist values are prefix-visible
+            # (JOIN/WHO/CHGHOST-fed) but VANISH when the last shared channel
+            # is parted — without caching, the next read would fall back to
+            # core's possibly-stale userhost or the rank-1 USERHOST value
+            # (the non-visible REAL host on solanum) and break the
+            # recipient-keyed DM context. Later host changes still win via
+            # the equal-rank JOIN/CHGHOST/396 handlers.
+            _set_own_handle($server, $n->{host}, 2);
+            return $n->{host};
         }
     }
     return $server->{userhost}

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -611,12 +611,61 @@ sub _incoming_ctx_for {
 
 # Both context forms a DM row can live under: the peer-keyed $ctx (config and
 # KEYREQ-direction trust markers) and the recipient-keyed `@<own>` (real
-# incoming sessions). Channels yield just themselves.
+# incoming sessions). Channels yield just themselves. READ-ONLY callers only:
+# trust-CHANGING commands must not use this — when the own handle is still
+# unknown it degrades to just ($ctx), which would silently skip the real
+# `@<own>` session. They use the handle-wide helpers below instead.
 sub _ctx_variants {
     my ($witem, $ctx) = @_;
     my $own_ctx = _incoming_ctx_for($witem ? $witem->{server} : undef, $ctx);
     my %seen;
     return grep { defined($_) && !$seen{$_}++ } ($ctx, $own_ctx);
+}
+
+# Set the trust status of a peer's incoming session(s); returns the count. A
+# DM trust change targets the PEER, not one context string: the real session
+# lives under `@<own>` (which may be UNKNOWN right now, e.g. right after
+# reconnect/reload before USERHOST/JOIN/396 seeds it), the trust marker under
+# `@<peer>`, plus possibly stale rows from handle drift — so update EVERY DM
+# row for the handle. Touching only the resolvable context would report
+# success while leaving the trusted `@<own>` session decryptable once the
+# handle is learned. Channels update exactly (handle, ctx).
+sub _set_incoming_trust {
+    my ($kr, $handle, $ctx, $status) = @_;
+    my $n = 0;
+    if ($ctx =~ /^\@/) {
+        for my $key (keys %{ $kr->{incoming} || {} }) {
+            my ($h, $c) = split /\|/, $key, 2;
+            next unless defined($c) && $h eq $handle && $c =~ /^\@/;
+            $kr->{incoming}{$key}{status} = $status;
+            $n++;
+        }
+    } elsif (my $row = $kr->{incoming}{"$handle|$ctx"}) {
+        $row->{status} = $status;
+        $n++;
+    }
+    return $n;
+}
+
+# Forget a peer's incoming (and pending-inbound) rows; same handle-wide DM
+# semantics as _set_incoming_trust (see there for why).
+sub _delete_incoming_rows {
+    my ($kr, $handle, $ctx) = @_;
+    my $n = 0;
+    for my $store ($kr->{incoming}, $kr->{pending_inbound}) {
+        next unless $store;
+        if ($ctx =~ /^\@/) {
+            for my $key (keys %{$store}) {
+                my ($h, $c) = split /\|/, $key, 2;
+                next unless defined($c) && $h eq $handle && $c =~ /^\@/;
+                delete $store->{$key};
+                $n++;
+            }
+        } else {
+            $n++ if delete $store->{"$handle|$ctx"};
+        }
+    }
+    return $n;
 }
 
 sub _find_peer_by_handle {
@@ -1337,15 +1386,9 @@ sub cmd_revoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    # DM sessions live under two contexts (recipient-keyed): real incoming
-    # sessions under `@<own>`, KEYREQ-direction trust markers under `@<peer>`
-    # (= $ctx). Revoke both so inbound decrypt — which honors only `@<own>` —
-    # actually stops trusting the peer.
-    for my $rctx (_ctx_variants($witem, $ctx)) {
-        if (my $row = $kr->{incoming}{"$handle|$rctx"}) {
-            $row->{status} = 'revoked';
-        }
-    }
+    # Handle-wide for DMs (see _set_incoming_trust for why — the `@<own>`
+    # session may be unreachable by name right now, but must still revoke).
+    _set_incoming_trust($kr, $handle, $ctx, 'revoked');
     delete $kr->{outgoing_recipients}{"$ctx|$handle"};
     if (my $out = $kr->{outgoing}{$ctx}) {
         $out->{pending_rotation} = 1;
@@ -1364,12 +1407,8 @@ sub cmd_unrevoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    # Mirror of revoke: restore trust under both DM context forms.
-    for my $rctx (_ctx_variants($witem, $ctx)) {
-        if (my $row = $kr->{incoming}{"$handle|$rctx"}) {
-            $row->{status} = 'trusted';
-        }
-    }
+    # Mirror of revoke: handle-wide for DMs (see _set_incoming_trust).
+    _set_incoming_trust($kr, $handle, $ctx, 'trusted');
     my ($fp_hex, $peer) = _find_peer_by_handle($kr, $handle);
     $peer->{status} = 'trusted' if $peer;
     save_keyring($kr);
@@ -1406,12 +1445,8 @@ sub cmd_forget {
     }
     my $ctx = _resolve_ctx_for_command($kr, $witem, $who);
     return _prnt_err($witem, "cannot resolve context for $who") unless defined $ctx;
-    # Delete both DM context forms (see cmd_revoke).
-    for my $store ($kr->{incoming}, $kr->{pending_inbound}) {
-        for my $rctx (_ctx_variants($witem, $ctx)) {
-            $removed++ if delete $store->{"$handle|$rctx"};
-        }
-    }
+    # Handle-wide for DMs (see _set_incoming_trust for why).
+    $removed += _delete_incoming_rows($kr, $handle, $ctx);
     save_keyring($kr);
     _prnt_ok($witem, "forgotten $who on $ctx");
 }

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -80,6 +80,19 @@ my $debug_log    = File::Spec->catfile($rpe2e_dir, 'rpe2e-debug.log');
 
 my %rate_limit_sent;
 
+# Our own server-stamped ident@host, per server tag — the recipient-keyed DM
+# context (docs/rpe2e-dm-addendum.md): DMs we RECEIVE are keyed `@<own>`.
+# VOLATILE by design (never persisted): reset at registration and re-seeded via
+# the one-shot self-USERHOST and our own CHGHOST. irssi core's
+# `$server->{userhost}` is the fallback seed (core fills it from our first own
+# JOIN and RPL_HOSTHIDDEN, but NOT on own CHGHOST and not before a join —
+# hence this store on top).
+my %own_handle;
+
+# Throttle for the "held — own identity not learned yet" notice, per
+# "<tag>|<nick>", so a chatty peer doesn't flood while we wait for USERHOST.
+my %own_wait_notice_at;
+
 sub _dbg {
     my ($msg) = @_;
     return unless $DEBUG_ENABLED;
@@ -518,6 +531,69 @@ sub _ctx_for_target {
     return '@' . $handle;
 }
 
+# One RPL_USERHOST (302) entry `nick[*]=[+|-]ident@host` → ($nick, $handle) or
+# (). Mirrors Rust `parse_userhost_reply`: the trailing `*` on the nick marks
+# an oper (stripped), the leading `+`/`-` on the userhost is the away flag
+# (stripped); the handle keeps `~` and any cloak verbatim.
+sub _parse_userhost_entry {
+    my ($entry) = @_;
+    return unless defined $entry && $entry =~ /^(.+?)=(.+)$/;
+    my ($nick, $userhost) = ($1, $2);
+    $nick =~ s/\*+\z//;
+    $userhost =~ s/^[+-]//;
+    return unless length($nick) && index($userhost, '@') > 0;
+    return ($nick, $userhost);
+}
+
+sub _set_own_handle {
+    my ($server, $handle) = @_;
+    return unless $server && defined $handle && length $handle;
+    my $tag = $server->{tag} // return;
+    if (($own_handle{$tag} // '') ne $handle) {
+        $own_handle{$tag} = $handle;
+        _dbg("own handle on $tag: $handle");
+    }
+}
+
+# Our own ident@host on this server, or undef while unknown. The script store
+# wins (it tracks own CHGHOST); irssi core's join-seeded value is the fallback.
+sub _own_handle_for {
+    my ($server) = @_;
+    return unless $server;
+    my $tag = $server->{tag} // '';
+    return $own_handle{$tag} // $server->{userhost};
+}
+
+# ONE-SHOT self-USERHOST to seed our own handle — gated to registration/load
+# events, never per message (the 302 reply is itself a message; a per-message
+# trigger would loop). Mirrors the Rust client's RPL_WELCOME one-shot.
+sub _send_self_userhost {
+    my ($server) = @_;
+    return unless $server && ($server->{nick} // '') ne '';
+    eval { $server->send_raw('USERHOST ' . $server->{nick}) };
+    _dbg("_send_self_userhost failed on " . ($server->{tag} // '?') . ": $@") if $@;
+}
+
+# Context that REAL incoming DM sessions live under: `@<own_handle>`
+# (recipient-keyed — the recipient of the direction is us). Channels pass
+# through unchanged. undef → our own handle is not known yet.
+sub _incoming_ctx_for {
+    my ($server, $ctx) = @_;
+    return $ctx if !defined($ctx) || $ctx !~ /^\@/;
+    my $own = _own_handle_for($server);
+    return defined($own) && length($own) ? '@' . $own : undef;
+}
+
+# Both context forms a DM row can live under: the peer-keyed $ctx (config and
+# KEYREQ-direction trust markers) and the recipient-keyed `@<own>` (real
+# incoming sessions). Channels yield just themselves.
+sub _ctx_variants {
+    my ($witem, $ctx) = @_;
+    my $own_ctx = _incoming_ctx_for($witem ? $witem->{server} : undef, $ctx);
+    my %seen;
+    return grep { defined($_) && !$seen{$_}++ } ($ctx, $own_ctx);
+}
+
 sub _find_peer_by_handle {
     my ($kr, $handle) = @_;
     for my $fp_hex (keys %{ $kr->{peers} }) {
@@ -713,8 +789,21 @@ sub _build_keyrsp_for_req {
         . "\x01";
 }
 
+# Context for OUR reciprocal KEYREQ. A reciprocal establishes the peer→us
+# direction, whose recipient-keyed context is OUR handle — not the requester's
+# context from their KEYREQ (that names the other direction). Channels pass
+# through. undef → own handle unknown; skip the reciprocal (the transport
+# self-heals later via auto-KEYREQ on their first wire).
+sub _reciprocal_ctx {
+    my ($channel, $own_handle) = @_;
+    return $channel if defined $channel && $channel =~ $CHANNEL_PREFIX_RE;
+    return defined($own_handle) && length($own_handle) ? '@' . $own_handle : undef;
+}
+
 sub _maybe_build_reciprocal_keyreq {
-    my ($kr, $channel, $sender_handle) = @_;
+    my ($kr, $channel, $sender_handle, $own_handle) = @_;
+    $channel = _reciprocal_ctx($channel, $own_handle);
+    return undef unless defined $channel;
     my $row = $kr->{incoming}{"$sender_handle|$channel"};
     my $pending = $kr->{pending}{ _pending_key($channel, $sender_handle) };
     my $already_trusted = $row && ($row->{status} // '') eq 'trusted';
@@ -723,7 +812,9 @@ sub _maybe_build_reciprocal_keyreq {
 }
 
 sub _build_reciprocal_keyreq_on_accept {
-    my ($kr, $channel, $sender_handle) = @_;
+    my ($kr, $channel, $sender_handle, $own_handle) = @_;
+    $channel = _reciprocal_ctx($channel, $own_handle);
+    return undef unless defined $channel;
     my $row = $kr->{incoming}{"$sender_handle|$channel"};
     my $already_trusted = $row && ($row->{status} // '') eq 'trusted';
     return undef if $already_trusted;
@@ -732,7 +823,7 @@ sub _build_reciprocal_keyreq_on_accept {
 }
 
 sub handle_keyreq {
-    my ($kr, $sender_handle, $nick, $body) = @_;
+    my ($kr, $sender_handle, $nick, $body, $own_handle) = @_;
     my $req = parse_keyreq($body);
     return (undef, undef, undef) unless $req;
     my $ctx = $req->{channel};
@@ -796,7 +887,7 @@ sub handle_keyreq {
         return (undef, undef, $ctx);
     }
     my $rsp = _build_keyrsp_for_req($kr, $ctx, $sender_handle, $req->{pub}, $req->{eph_x25519});
-    my $reciprocal = _maybe_build_reciprocal_keyreq($kr, $ctx, $sender_handle);
+    my $reciprocal = _maybe_build_reciprocal_keyreq($kr, $ctx, $sender_handle, $own_handle);
     return ($rsp, $reciprocal, $ctx);
 }
 
@@ -1016,8 +1107,10 @@ sub _resolve_ctx_for_command {
     return undef unless $witem;
     my $target = $witem->{name};
     return $target if $target =~ $CHANNEL_PREFIX_RE;
-    my $handle = _find_handle_by_nick($kr, $nick || $target);
-    return defined $handle ? '@' . $handle : undef;
+    # DM: LIVE-first resolution (open query / shared channel), falling back to
+    # the peers cache — a first-time `/e2e on` in a query has no cache entry.
+    my $handle = _resolve_dm_handle($witem->{server}, $kr, $nick || $target);
+    return defined $handle && length $handle ? '@' . $handle : undef;
 }
 
 sub _resolve_handle_for_command {
@@ -1026,40 +1119,41 @@ sub _resolve_handle_for_command {
     return _find_handle_by_nick($kr, $nick_or_handle);
 }
 
+# /e2e on|off|mode work in a channel OR a query: the config is keyed by the
+# channel name or the PEER-keyed DM context `@<peer_handle>` ("E2E with that
+# peer") — the recipient-keyed wire contexts are derived where they are used
+# (matching weechat and the Rust client, which have always allowed DM enable).
 sub cmd_on {
     my ($witem) = @_;
-    unless ($witem && ($witem->{name} // '') =~ $CHANNEL_PREFIX_RE) {
-        return _prnt_err(undef, 'not on a channel');
-    }
     my $kr = load_keyring();
-    $kr->{channels}{ $witem->{name} } = { enabled => 1, mode => 'normal' };
+    my $ctx = _resolve_ctx_for_command($kr, $witem, undef);
+    return _prnt_err($witem, 'not in a channel or query (or peer handle unknown — wait for a message from them)') unless defined $ctx;
+    $kr->{channels}{$ctx} = { enabled => 1, mode => 'normal' };
     save_keyring($kr);
-    _prnt_ok($witem, "enabled on " . $witem->{name} . " (mode=normal)");
+    _prnt_ok($witem, "enabled on $ctx (mode=normal)");
 }
 
 sub cmd_off {
     my ($witem) = @_;
-    unless ($witem && ($witem->{name} // '') =~ $CHANNEL_PREFIX_RE) {
-        return _prnt_err(undef, 'not on a channel');
-    }
     my $kr = load_keyring();
-    $kr->{channels}{ $witem->{name} } = { enabled => 0, mode => $kr->{channels}{ $witem->{name} }{mode} // 'normal' };
+    my $ctx = _resolve_ctx_for_command($kr, $witem, undef);
+    return _prnt_err($witem, 'not in a channel or query (or peer handle unknown — wait for a message from them)') unless defined $ctx;
+    $kr->{channels}{$ctx} = { enabled => 0, mode => $kr->{channels}{$ctx}{mode} // 'normal' };
     save_keyring($kr);
-    _prnt_ok($witem, "disabled on " . $witem->{name});
+    _prnt_ok($witem, "disabled on $ctx");
 }
 
 sub cmd_mode {
     my ($witem, $mode) = @_;
-    unless ($witem && ($witem->{name} // '') =~ $CHANNEL_PREFIX_RE) {
-        return _prnt_err(undef, 'not on a channel');
-    }
     $mode //= 'normal';
     $mode = 'auto-accept' if $mode eq 'auto';
     return _prnt_err($witem, "invalid mode: $mode") unless $mode =~ /^(auto-accept|normal|quiet)$/;
     my $kr = load_keyring();
-    $kr->{channels}{ $witem->{name} } = { enabled => 1, mode => $mode };
+    my $ctx = _resolve_ctx_for_command($kr, $witem, undef);
+    return _prnt_err($witem, 'not in a channel or query (or peer handle unknown — wait for a message from them)') unless defined $ctx;
+    $kr->{channels}{$ctx} = { enabled => 1, mode => $mode };
     save_keyring($kr);
-    _prnt_ok($witem, "mode=$mode on " . $witem->{name});
+    _prnt_ok($witem, "mode=$mode on $ctx");
 }
 
 sub cmd_fingerprint {
@@ -1122,7 +1216,12 @@ sub cmd_list {
     }
     my $ctx = _resolve_ctx_for_command($kr, $witem, undef);
     return _prnt_err($witem, 'cannot resolve current context') unless defined $ctx;
-    my @rows = grep { (split(/\|/, $_, 2))[1] eq $ctx } keys %{ $kr->{incoming} || {} };
+    # Query buffer: real DM sessions are recipient-keyed under `@<own>`, trust
+    # markers under `@<peer>` — list everything from this peer regardless of
+    # context. Channel buffers filter by the channel as before.
+    my @rows = $ctx =~ /^\@/
+        ? grep { (split(/\|/, $_, 2))[0] eq substr($ctx, 1) } keys %{ $kr->{incoming} || {} }
+        : grep { (split(/\|/, $_, 2))[1] eq $ctx } keys %{ $kr->{incoming} || {} };
     if (!@rows) {
         return _prnt_ok($witem, 'no peers');
     }
@@ -1142,8 +1241,14 @@ sub cmd_handshake {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $ctx;
     my $cfg = $kr->{channels}{$ctx};
     return _prnt_err($witem, "e2e not enabled on $ctx") unless $cfg && ($cfg->{enabled} // 0);
+    # A KEYREQ asks the peer for the key of the direction WE receive, so for a
+    # DM it is stamped with OUR handle (recipient-keyed) — the peer-keyed $ctx
+    # above is only the config key.
+    my $kreq_ctx = _incoming_ctx_for($server, $ctx);
+    return _prnt_err($witem, 'own identity not learned yet (waiting for the USERHOST reply) — try again in a moment')
+        unless defined $kreq_ctx;
     my $handle = _resolve_handle_for_command($kr, $nick);
-    my $wire = eval { build_keyreq($kr, $ctx, $handle) };
+    my $wire = eval { build_keyreq($kr, $kreq_ctx, $handle) };
     return _prnt_err($witem, "handshake failed: $@") if $@ || !defined $wire;
     save_keyring($kr);
     _send_raw_notice($server, $nick, $wire);
@@ -1162,7 +1267,7 @@ sub cmd_accept {
     my $pending = delete $kr->{pending_inbound}{"$handle|$ctx"};
     if ($pending) {
         my $rsp = _build_keyrsp_for_req($kr, $ctx, $handle, b64d($pending->{pubkey}), b64d($pending->{eph_x25519}));
-        my $reciprocal = eval { _build_reciprocal_keyreq_on_accept($kr, $ctx, $handle) };
+        my $reciprocal = eval { _build_reciprocal_keyreq_on_accept($kr, $ctx, $handle, _own_handle_for($server)) };
         if ($@) {
             _dbg("cmd_accept reciprocal build failed for $nick ($handle) on $ctx: $@");
             $reciprocal = undef;
@@ -1207,8 +1312,14 @@ sub cmd_revoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    if (my $row = $kr->{incoming}{"$handle|$ctx"}) {
-        $row->{status} = 'revoked';
+    # DM sessions live under two contexts (recipient-keyed): real incoming
+    # sessions under `@<own>`, KEYREQ-direction trust markers under `@<peer>`
+    # (= $ctx). Revoke both so inbound decrypt — which honors only `@<own>` —
+    # actually stops trusting the peer.
+    for my $rctx (_ctx_variants($witem, $ctx)) {
+        if (my $row = $kr->{incoming}{"$handle|$rctx"}) {
+            $row->{status} = 'revoked';
+        }
     }
     delete $kr->{outgoing_recipients}{"$ctx|$handle"};
     if (my $out = $kr->{outgoing}{$ctx}) {
@@ -1228,8 +1339,11 @@ sub cmd_unrevoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    if (my $row = $kr->{incoming}{"$handle|$ctx"}) {
-        $row->{status} = 'trusted';
+    # Mirror of revoke: restore trust under both DM context forms.
+    for my $rctx (_ctx_variants($witem, $ctx)) {
+        if (my $row = $kr->{incoming}{"$handle|$rctx"}) {
+            $row->{status} = 'trusted';
+        }
     }
     my ($fp_hex, $peer) = _find_peer_by_handle($kr, $handle);
     $peer->{status} = 'trusted' if $peer;
@@ -1267,10 +1381,10 @@ sub cmd_forget {
     }
     my $ctx = _resolve_ctx_for_command($kr, $witem, $who);
     return _prnt_err($witem, "cannot resolve context for $who") unless defined $ctx;
+    # Delete both DM context forms (see cmd_revoke).
     for my $store ($kr->{incoming}, $kr->{pending_inbound}) {
-        my $key = "$handle|$ctx";
-        if (delete $store->{$key}) {
-            $removed++;
+        for my $rctx (_ctx_variants($witem, $ctx)) {
+            $removed++ if delete $store->{"$handle|$rctx"};
         }
     }
     save_keyring($kr);
@@ -1285,7 +1399,10 @@ sub cmd_verify {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    my $row = $kr->{incoming}{"$handle|$ctx"};
+    # Real DM sessions are recipient-keyed under `@<own>`; fall back to the
+    # peer-keyed trust marker if only that exists.
+    my ($row) = grep { defined }
+        map { $kr->{incoming}{"$handle|$_"} } reverse _ctx_variants($witem, $ctx);
     return _prnt_err($witem, "no session for $nick on $ctx") unless $row;
     my (undef, undef, $local_fp) = ensure_identity();
     _prnt_ok($witem, 'Fingerprint Verification');
@@ -1798,7 +1915,32 @@ sub _decrypt_wire_message {
     my $wire = parse_wire($msg);
     return (0, undef) unless $wire;
     my $handle = $host;
-    my $ctx = _ctx_for_target($target, $handle);
+    my $ctx;
+    my $is_dm = !(defined $target && $target =~ $CHANNEL_PREFIX_RE);
+    if ($is_dm) {
+        # DM: recipient-keyed context (docs/rpe2e-dm-addendum.md) — WE are the
+        # recipient, so the context is OUR handle, never the sender's.
+        my $own = _own_handle_for($server);
+        unless (defined $own && length $own) {
+            # Own handle not learned yet (e.g. right after connect, before the
+            # self-USERHOST reply). Do NOT fall back to `@<sender>` —
+            # decrypting or KEYREQ-ing under it would negotiate the WRONG DM
+            # direction. Drop; the peer's next message re-establishes once the
+            # handle is known.
+            my $wait_key = ($server->{tag} // '') . "|$nick";
+            if (now_unix() - ($own_wait_notice_at{$wait_key} // 0) >= $KEYREQ_MIN_INTERVAL) {
+                $own_wait_notice_at{$wait_key} = now_unix();
+                _prnt_warn(_notice_witem_for_ctx($server, $nick, $nick),
+                           "encrypted DM from $nick held — own identity not learned yet (waiting for the USERHOST reply)");
+            }
+            _dbg("DM wire from $nick but own handle unknown on " . ($server->{tag} // '?'));
+            Irssi::signal_stop();
+            return (1, undef);
+        }
+        $ctx = '@' . $own;
+    } else {
+        $ctx = $target;
+    }
     my $kr = load_keyring();
     _dbg("wire from $nick!$handle -> $target part=$wire->{part}/$wire->{total}");
     if (abs(now_unix() - $wire->{ts}) > $TS_TOLERANCE) {
@@ -1822,7 +1964,11 @@ sub _decrypt_wire_message {
     if (!$row || ($row->{status} // '') ne 'trusted') {
         _prnt_dbg($server, $ctx, $nick, "no trusted incoming for ($handle,$ctx)");
         if (_allow_outgoing_keyreq($handle)) {
-            my $cfg = $kr->{channels}{$ctx};
+            # The enable gate is the PEER-keyed config ("E2E with that peer");
+            # the KEYREQ context is the direction's recipient — us ($ctx is
+            # already @<own> for a DM, the channel itself otherwise).
+            my $cfg_ctx = $is_dm ? '@' . $handle : $ctx;
+            my $cfg = $kr->{channels}{$cfg_ctx};
             if ($cfg && ($cfg->{enabled} // 0)) {
                 my $req = eval { build_keyreq($kr, $ctx, $handle) };
                 if (!$@ && defined $req) {
@@ -1847,6 +1993,45 @@ sub _decrypt_wire_message {
     my $decoded = eval { decode('UTF-8', $pt, FB_DEFAULT) };
     $decoded = decode('UTF-8', $pt) if !defined $decoded;
     return (1, $decoded);
+}
+
+# Registration complete: RESET the own handle (the server may assign a
+# different ident/host/cloak this session) and re-seed it with the one-shot
+# self-USERHOST. irssi core also clears `$server->{userhost}` on disconnect,
+# so the fallback never goes stale either.
+sub signal_event_001 {
+    my ($server, $data, $nick, $address) = @_;
+    return unless $server;
+    delete $own_handle{ $server->{tag} // '' };
+    _send_self_userhost($server);
+}
+
+# RPL_USERHOST: seed our own handle from any entry matching our nick (the
+# self-USERHOST on connect, or any later USERHOST that includes us).
+# Observe-only — never stops the signal (irssi core reads 302 for away flags).
+sub signal_event_302 {
+    my ($server, $data) = @_;
+    return unless $server && defined $data;
+    my ($replies) = $data =~ /:(.*)$/s;
+    $replies //= $data;
+    my $own_nick = lc($server->{nick} // '');
+    return unless length $own_nick;
+    for my $entry (split ' ', $replies) {
+        my ($n, $handle) = _parse_userhost_entry($entry);
+        next unless defined $n && lc($n) eq $own_nick;
+        _set_own_handle($server, $handle);
+    }
+}
+
+# CHGHOST: track our OWN handle (peer handles are read live from prefixes and
+# nicklists; irssi core updates nicklists itself but NOT its own userhost).
+sub signal_event_chghost {
+    my ($server, $data, $nick, $address) = @_;
+    return unless $server && defined $data && defined $nick;
+    return unless lc($nick) eq lc($server->{nick} // '');
+    my ($newuser, $newhost) = $data =~ /^(\S+)\s+:?(\S+)/;
+    return unless defined $newuser && defined $newhost;
+    _set_own_handle($server, "$newuser\@$newhost");
 }
 
 # F2: decrypt on `event privmsg` — the irssi analog of weechat's raw-line
@@ -1905,7 +2090,8 @@ sub _handle_rpee2e_ctcp_reply {
         my $parsed = parse_keyreq($inner);
         my $ctx = $parsed ? $parsed->{channel} : '';
         _prnt_dbg($server, $ctx, $nick, "RX KEYREQ from $nick ($sender_handle) for $ctx") if $parsed;
-        my ($rsp, $reciprocal, $ctx_unused) = handle_keyreq($kr, $sender_handle, $nick, $inner);
+        my ($rsp, $reciprocal, $ctx_unused) =
+            handle_keyreq($kr, $sender_handle, $nick, $inner, _own_handle_for($server));
         save_keyring($kr);
         if ($parsed && !$rsp && exists $kr->{pending_inbound}{"$sender_handle|$ctx"}) {
             my $witem = _notice_witem_for_ctx($server, $ctx, $nick);
@@ -2003,6 +2189,22 @@ Irssi::signal_add_first('event privmsg', \&signal_event_privmsg);
 Irssi::signal_add_first('ctcp reply RPEE2E', \&signal_ctcp_reply_rpee2e);
 Irssi::signal_add_first('ctcp reply', \&signal_ctcp_reply_generic);
 Irssi::signal_add_first('default ctcp reply', \&signal_default_ctcp_reply_generic);
+# Own-handle tracking for the recipient-keyed DM context
+# (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 302
+# (self-USERHOST reply) and our own CHGHOST. Plain observers — never stop
+# these signals (irssi core reads 302 for away flags itself).
+Irssi::signal_add('event 001', \&signal_event_001);
+Irssi::signal_add('event 302', \&signal_event_302);
+Irssi::signal_add('event chghost', \&signal_event_chghost);
+# Script (re)loaded mid-session: `event 001` will not fire for servers that
+# are already up — seed their own handle now (irssi's own join-seeded
+# `$server->{userhost}` already covers those that joined a channel).
+for my $server (Irssi::servers()) {
+    next unless $server->{connected};
+    my $known = _own_handle_for($server);
+    next if defined $known && length $known;
+    _send_self_userhost($server);
+}
 
 Irssi::print("RPE2E $VERSION loaded — /e2e fingerprint to see your fingerprint");
 

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -601,6 +601,20 @@ sub _incoming_ctx_for {
     return defined($own) && length($own) ? '@' . $own : undef;
 }
 
+# The `@<own>` context a DM trust change on THIS server must also touch.
+# Channels: the ctx itself. DMs with the own handle still unknown: print the
+# refusal (the state is transient — one WHOIS round-trip) and return undef;
+# guessing or sweeping handle-wide would either miss the real session or
+# mutate other networks' rows (see _set_incoming_trust).
+sub _own_ctx_or_warn {
+    my ($witem, $ctx, $cmd) = @_;
+    return $ctx unless defined $ctx && $ctx =~ /^\@/;
+    my $own_ctx = _incoming_ctx_for($witem ? $witem->{server} : undef, $ctx);
+    _prnt_err($witem, "$cmd: own identity not learned yet (waiting for the WHOIS reply) — try again in a moment")
+        unless defined $own_ctx;
+    return $own_ctx;
+}
+
 # Both context forms a DM row can live under: the peer-keyed $ctx (config and
 # KEYREQ-direction trust markers) and the recipient-keyed `@<own>` (real
 # incoming sessions). Channels yield just themselves. READ-ONLY callers only:
@@ -614,47 +628,41 @@ sub _ctx_variants {
     return grep { defined($_) && !$seen{$_}++ } ($ctx, $own_ctx);
 }
 
-# Set the trust status of a peer's incoming session(s); returns the count. A
-# DM trust change targets the PEER, not one context string: the real session
-# lives under `@<own>` (which may be UNKNOWN right now, e.g. right after
-# reconnect/reload before WHOIS/JOIN/396 seeds it), the trust marker under
-# `@<peer>`, plus possibly stale rows from handle drift — so update EVERY DM
-# row for the handle. Touching only the resolvable context would report
-# success while leaving the trusted `@<own>` session decryptable once the
-# handle is learned. Channels update exactly (handle, ctx).
+# Set the trust status of a peer's incoming session(s); returns the count.
+# A DM trust change touches EXACTLY this server's two context forms: the
+# real session under `@<own>` ($own_ctx, resolved by the caller — which
+# REFUSES the command while the own handle is unknown, a transient
+# one-WHOIS-round-trip state) and the `@<peer>` trust marker ($ctx). Never
+# wider: the keyring has no network scoping (F3, deferred), so a handle-wide
+# sweep would silently mutate the SAME peer's DM state on OTHER connected
+# networks. Matches the Rust client, whose trust commands operate on
+# current_e2e_own_context and error out without it. Known shared residual
+# (Rust has it too, F3 subsumes): rows under a long-gone `@<old own>` from
+# handle drift are not touched. Channels update exactly (handle, ctx).
 sub _set_incoming_trust {
-    my ($kr, $handle, $ctx, $status) = @_;
+    my ($kr, $handle, $ctx, $status, $own_ctx) = @_;
     my $n = 0;
-    if ($ctx =~ /^\@/) {
-        for my $key (keys %{ $kr->{incoming} || {} }) {
-            my ($h, $c) = split /\|/, $key, 2;
-            next unless defined($c) && $h eq $handle && $c =~ /^\@/;
-            $kr->{incoming}{$key}{status} = $status;
+    my %seen;
+    for my $rctx (grep { defined($_) && !$seen{$_}++ } ($ctx, $own_ctx)) {
+        if (my $row = $kr->{incoming}{"$handle|$rctx"}) {
+            $row->{status} = $status;
             $n++;
         }
-    } elsif (my $row = $kr->{incoming}{"$handle|$ctx"}) {
-        $row->{status} = $status;
-        $n++;
     }
     return $n;
 }
 
-# Forget a peer's incoming (and pending-inbound) rows; same handle-wide DM
+# Forget a peer's incoming (and pending-inbound) rows; same exact-context DM
 # semantics as _set_incoming_trust (see there for why).
 sub _delete_incoming_rows {
-    my ($kr, $handle, $ctx) = @_;
+    my ($kr, $handle, $ctx, $own_ctx) = @_;
     my $n = 0;
+    my %seen;
     for my $store ($kr->{incoming}, $kr->{pending_inbound}) {
         next unless $store;
-        if ($ctx =~ /^\@/) {
-            for my $key (keys %{$store}) {
-                my ($h, $c) = split /\|/, $key, 2;
-                next unless defined($c) && $h eq $handle && $c =~ /^\@/;
-                delete $store->{$key};
-                $n++;
-            }
-        } else {
-            $n++ if delete $store->{"$handle|$ctx"};
+        %seen = ();
+        for my $rctx (grep { defined($_) && !$seen{$_}++ } ($ctx, $own_ctx)) {
+            $n++ if delete $store->{"$handle|$rctx"};
         }
     }
     return $n;
@@ -1378,9 +1386,10 @@ sub cmd_revoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    # Handle-wide for DMs (see _set_incoming_trust for why — the `@<own>`
-    # session may be unreachable by name right now, but must still revoke).
-    _set_incoming_trust($kr, $handle, $ctx, 'revoked');
+    # Exact-context for DMs (see _set_incoming_trust for why).
+    my $own_ctx = _own_ctx_or_warn($witem, $ctx, '/e2e revoke');
+    return unless defined $own_ctx;
+    _set_incoming_trust($kr, $handle, $ctx, 'revoked', $own_ctx);
     delete $kr->{outgoing_recipients}{"$ctx|$handle"};
     if (my $out = $kr->{outgoing}{$ctx}) {
         $out->{pending_rotation} = 1;
@@ -1399,8 +1408,10 @@ sub cmd_unrevoke {
     return _prnt_err($witem, "cannot resolve handle for $nick") unless defined $handle;
     my $ctx = _resolve_ctx_for_command($kr, $witem, $nick);
     return _prnt_err($witem, "cannot resolve context for $nick") unless defined $ctx;
-    # Mirror of revoke: handle-wide for DMs (see _set_incoming_trust).
-    _set_incoming_trust($kr, $handle, $ctx, 'trusted');
+    # Mirror of revoke: exact-context for DMs (see _set_incoming_trust).
+    my $own_ctx = _own_ctx_or_warn($witem, $ctx, '/e2e unrevoke');
+    return unless defined $own_ctx;
+    _set_incoming_trust($kr, $handle, $ctx, 'trusted', $own_ctx);
     my ($fp_hex, $peer) = _find_peer_by_handle($kr, $handle);
     $peer->{status} = 'trusted' if $peer;
     save_keyring($kr);
@@ -1437,8 +1448,10 @@ sub cmd_forget {
     }
     my $ctx = _resolve_ctx_for_command($kr, $witem, $who);
     return _prnt_err($witem, "cannot resolve context for $who") unless defined $ctx;
-    # Handle-wide for DMs (see _set_incoming_trust for why).
-    $removed += _delete_incoming_rows($kr, $handle, $ctx);
+    # Exact-context for DMs (see _set_incoming_trust for why).
+    my $own_ctx = _own_ctx_or_warn($witem, $ctx, '/e2e forget');
+    return unless defined $own_ctx;
+    $removed += _delete_incoming_rows($kr, $handle, $ctx, $own_ctx);
     save_keyring($kr);
     _prnt_ok($witem, "forgotten $who on $ctx");
 }

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -82,11 +82,19 @@ my %rate_limit_sent;
 
 # Our own server-stamped ident@host, per server tag — the recipient-keyed DM
 # context (docs/rpe2e-dm-addendum.md): DMs we RECEIVE are keyed `@<own>`.
-# VOLATILE by design (never persisted): reset at registration and re-seeded via
-# the one-shot self-USERHOST and our own CHGHOST. irssi core's
-# `$server->{userhost}` is the fallback seed (core fills it from our first own
-# JOIN and RPL_HOSTHIDDEN, but NOT on own CHGHOST and not before a join —
-# hence this store on top).
+# VOLATILE by design (never persisted): reset at registration and re-seeded.
+#
+# Sources are RANKED, because they disagree on cloaked networks: what matters
+# is the handle as PEERS see it (our message prefix), and solanum-family ircds
+# (Libera) answer a self-USERHOST with the REAL host, not the cloak.
+#   rank 2 — prefix-visible: our own JOIN, our own CHGHOST, RPL_HOSTHIDDEN
+#            (396). Authoritative.
+#   rank 1 — self-USERHOST (302) reply: seed of last resort (a DM-only user
+#            on zero channels produces no rank-2 event).
+# A lower rank never overwrites a higher one; reads prefer rank 2, then a live
+# own-nicklist lookup (irssi keeps nicklists current, incl. CHGHOST), then
+# core's join/396-seeded `$server->{userhost}`, then rank 1.
+# Values: { handle => ..., rank => ... }, keyed by server tag.
 my %own_handle;
 
 # Throttle for the "held — own identity not learned yet" notice, per
@@ -546,22 +554,39 @@ sub _parse_userhost_entry {
 }
 
 sub _set_own_handle {
-    my ($server, $handle) = @_;
+    my ($server, $handle, $rank) = @_;
     return unless $server && defined $handle && length $handle;
+    $rank //= 2;
     my $tag = $server->{tag} // return;
-    if (($own_handle{$tag} // '') ne $handle) {
-        $own_handle{$tag} = $handle;
-        _dbg("own handle on $tag: $handle");
+    my $cur = $own_handle{$tag};
+    return if $cur && $cur->{rank} > $rank;   # prefix-visible never yields to USERHOST
+    if (!$cur || $cur->{handle} ne $handle || $cur->{rank} != $rank) {
+        $own_handle{$tag} = { handle => $handle, rank => $rank };
+        _dbg("own handle on $tag: $handle (rank $rank)");
     }
 }
 
-# Our own ident@host on this server, or undef while unknown. The script store
-# wins (it tracks own CHGHOST); irssi core's join-seeded value is the fallback.
+# Best current view of our own PEER-VISIBLE ident@host, or undef while
+# unknown. Priority: rank-2 store → our own nick on any joined channel's
+# nicklist (irssi keeps it current, incl. CHGHOST) → core's join/396-seeded
+# `$server->{userhost}` → rank-1 store (self-USERHOST; solanum-family ircds
+# answer that with the REAL host, so it is last).
 sub _own_handle_for {
     my ($server) = @_;
     return unless $server;
     my $tag = $server->{tag} // '';
-    return $own_handle{$tag} // $server->{userhost};
+    my $entry = $own_handle{$tag};
+    return $entry->{handle} if $entry && $entry->{rank} >= 2;
+    my $nick = $server->{nick} // '';
+    if (length $nick) {
+        for my $ch (eval { $server->channels() }) {
+            my $n = eval { $ch->nick_find($nick) };
+            return $n->{host} if $n && $n->{host};
+        }
+    }
+    return $server->{userhost}
+        if defined $server->{userhost} && length $server->{userhost};
+    return $entry ? $entry->{handle} : undef;
 }
 
 # ONE-SHOT self-USERHOST to seed our own handle — gated to registration/load
@@ -2007,8 +2032,11 @@ sub signal_event_001 {
 }
 
 # RPL_USERHOST: seed our own handle from any entry matching our nick (the
-# self-USERHOST on connect, or any later USERHOST that includes us).
-# Observe-only — never stops the signal (irssi core reads 302 for away flags).
+# self-USERHOST on connect, or any later USERHOST that includes us). Rank 1:
+# solanum-family ircds (Libera) answer a SELF-query with the REAL host, not
+# the cloak peers see — this only fills a hole, never overrides a
+# prefix-visible source. Observe-only — never stops the signal (irssi core
+# reads 302 for away flags).
 sub signal_event_302 {
     my ($server, $data) = @_;
     return unless $server && defined $data;
@@ -2019,8 +2047,37 @@ sub signal_event_302 {
     for my $entry (split ' ', $replies) {
         my ($n, $handle) = _parse_userhost_entry($entry);
         next unless defined $n && lc($n) eq $own_nick;
-        _set_own_handle($server, $handle);
+        _set_own_handle($server, $handle, 1);
     }
+}
+
+# Our own JOIN carries our prefix exactly as peers see it — the strongest
+# own-handle source irssi has (no echo-message support), and present right
+# after connect (autojoin). irssi core only copies it into
+# `$server->{userhost}` when that is still NULL; we track every occurrence.
+sub signal_event_join_own {
+    my ($server, $data, $nick, $address) = @_;
+    return unless $server && defined $nick && defined $address && length $address;
+    return unless lc($nick) eq lc($server->{nick} // '');
+    _set_own_handle($server, $address, 2);
+}
+
+# RPL_HOSTHIDDEN (396): the server telling US our new DISPLAYED host —
+# peer-visible by definition. Host-only form merges with the known ident.
+# Sanity checks mirror irssi core's event_hosthidden.
+sub signal_event_396 {
+    my ($server, $data) = @_;
+    return unless $server && defined $data;
+    my ($newhost) = $data =~ /^\S+\s+:?(\S+)/;
+    return unless defined $newhost && length $newhost;
+    return if $newhost =~ /[*?!#&\s]/ || $newhost =~ /^[@:\-]/ || $newhost =~ /-$/;
+    if (index($newhost, '@') > 0) {
+        _set_own_handle($server, $newhost, 2);
+        return;
+    }
+    my $cur = _own_handle_for($server);
+    return unless defined $cur && $cur =~ /^([^@]+)@/;
+    _set_own_handle($server, "$1\@$newhost", 2);
 }
 
 # CHGHOST: track our OWN handle (peer handles are read live from prefixes and
@@ -2196,13 +2253,16 @@ Irssi::signal_add_first('default ctcp reply', \&signal_default_ctcp_reply_generi
 Irssi::signal_add('event 001', \&signal_event_001);
 Irssi::signal_add('event 302', \&signal_event_302);
 Irssi::signal_add('event chghost', \&signal_event_chghost);
+Irssi::signal_add('event join', \&signal_event_join_own);
+Irssi::signal_add('event 396', \&signal_event_396);
 # Script (re)loaded mid-session: `event 001` will not fire for servers that
-# are already up — seed their own handle now (irssi's own join-seeded
-# `$server->{userhost}` already covers those that joined a channel).
+# are already up — seed their own handle now. Sent UNCONDITIONALLY: core's
+# `$server->{userhost}` can be stale (it is not updated on own CHGHOST), so
+# skipping when a fallback merely exists would pin the stale value until
+# reconnect. The reply seeds only rank 1, so it can never clobber a
+# prefix-visible value; live nicklist/core lookups still outrank it.
 for my $server (Irssi::servers()) {
     next unless $server->{connected};
-    my $known = _own_handle_for($server);
-    next if defined $known && length $known;
     _send_self_userhost($server);
 }
 

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -1968,8 +1968,11 @@ sub _decrypt_wire_message {
     return (0, undef) unless $wire;
     my $handle = $host;
     my $ctx;
+    my $is_own_line = $server && lc($nick) eq lc($server->{nick} // '');
     my $is_dm = !(defined $target && $target =~ $CHANNEL_PREFIX_RE);
-    if ($is_dm) {
+    if ($is_own_line) {
+        $ctx = '(own copy)';   # display-only; the real ctx is resolved below
+    } elsif ($is_dm) {
         # DM: recipient-keyed context (docs/rpe2e-dm-addendum.md) — WE are the
         # recipient, so the context is OUR handle, never the sender's.
         my $own = _own_handle_for($server);
@@ -1997,6 +2000,35 @@ sub _decrypt_wire_message {
     _dbg("wire from $nick!$handle -> $target part=$wire->{part}/$wire->{total}");
     if (abs(now_unix() - $wire->{ts}) > $TS_TOLERANCE) {
         _prnt_dbg($server, $ctx, $nick, "drop ciphertext from $nick ($handle): timestamp skew");
+        Irssi::signal_stop();
+        return (1, undef);
+    }
+    if ($is_own_line) {
+        # A wire with OUR prefix. irssi has no echo-message, so this is a
+        # bouncer relay from another attached client or FRESH playback (older
+        # replays were just dropped by the ts-skew check). Never a handle
+        # source (irssi core strips IRCv3 tags here, so live cannot be told
+        # from replay) and never an auto-KEYREQ target (that would be
+        # ourselves) — decrypt with OUR outgoing key so the copy renders
+        # instead of disappearing; undecryptable (rotated key) → quiet drop.
+        my @own_ctxs;
+        if (defined $target && $target =~ $CHANNEL_PREFIX_RE) {
+            @own_ctxs = ($target, @{ $alt_ctxs // [] });
+        } else {
+            my $h = _resolve_dm_handle($server, $kr, $target);
+            @own_ctxs = ('@' . $h) if defined $h && length $h;
+        }
+        for my $octx (@own_ctxs) {
+            my $out = $kr->{outgoing}{$octx};
+            next unless $out && $out->{sk};
+            my $aad2 = build_aad($octx, $wire->{msgid}, $wire->{ts}, $wire->{part}, $wire->{total});
+            my $pt2 = aead_decrypt(b64d($out->{sk}), $wire->{nonce}, $aad2, $wire->{ct});
+            next unless defined $pt2;
+            my $dec = eval { decode('UTF-8', $pt2, FB_DEFAULT) };
+            $dec = decode('UTF-8', $pt2) if !defined $dec;
+            return (1, $dec);
+        }
+        _dbg("own-copy wire to $target undecryptable (rotated key?) — dropped");
         Irssi::signal_stop();
         return (1, undef);
     }
@@ -2129,10 +2161,12 @@ sub signal_event_privmsg {
     # prefers whichever holds a trusted session (see _channel_readings).
     my @readings = _channel_readings($target);
     my $is_channel = scalar @readings;
-    # Context target: channel → most-stripped reading; DM → the SENDER's nick
-    # (DM context is keyed off the sender's handle, matching the old
-    # message-private path).
-    my $ctx_target = $is_channel ? $readings[0] : $nick;
+    # Context target: channel → most-stripped reading; DM → the SENDER's
+    # nick... unless the "sender" is US (a bouncer relay from another
+    # attached client, or playback), where the conversation is named by the
+    # RECIPIENT ($target).
+    my $is_own_line = $server && lc($nick) eq lc($server->{nick} // '');
+    my $ctx_target = $is_channel ? $readings[0] : ($is_own_line ? $target : $nick);
     my $alt_ctxs = @readings > 1 ? [@readings[1 .. $#readings]] : undef;
     # _decrypt_wire_message returns (0, undef) for a non-RPE2E line (no second
     # parse needed here), (1, undef) when it already dropped the ciphertext, or

--- a/scripts/irssi/rpe2e.pl
+++ b/scripts/irssi/rpe2e.pl
@@ -84,21 +84,23 @@ my %rate_limit_sent;
 # context (docs/rpe2e-dm-addendum.md): DMs we RECEIVE are keyed `@<own>`.
 # VOLATILE by design (never persisted): reset at registration and re-seeded.
 #
-# Sources are RANKED, because they disagree on cloaked networks: what matters
-# is the handle as PEERS see it (our message prefix), and solanum-family ircds
-# (Libera) answer a self-USERHOST with the REAL host, not the cloak.
-#   rank 2 — prefix-visible: our own JOIN, our own CHGHOST, RPL_HOSTHIDDEN
-#            (396). Authoritative.
-#   rank 1 — self-USERHOST (302) reply: seed of last resort (a DM-only user
-#            on zero channels produces no rank-2 event).
-# A lower rank never overwrites a higher one; reads prefer rank 2, then a live
-# own-nicklist lookup (irssi keeps nicklists current, incl. CHGHOST), then
-# core's join/396-seeded `$server->{userhost}`, then rank 1.
-# Values: { handle => ..., rank => ... }, keyed by server tag.
+# ONLY PREFIX-VISIBLE sources are ever stored — values peers themselves see
+# in our message prefix: our own JOIN, our own CHGHOST, RPL_HOSTHIDDEN (396),
+# self-WHOIS RPL_WHOISUSER (311 — the DISPLAYED host by definition; solanum
+# reveals the real host only in 338, which we never parse), and the
+# own-nicklist lookup in _own_handle_for. Self-view or possibly-stale sources
+# are deliberately NOT used at all: a self-USERHOST on solanum-family ircds
+# (Libera) answers with the REAL host, and irssi core's `$server->{userhost}`
+# is not updated on our own CHGHOST — ANY tier that can disagree with the
+# prefix breaks the recipient-keyed DM context sooner or later. While no
+# source has fired yet, the handle is simply UNKNOWN (transient — the
+# one-shot self-WHOIS at registration/load answers within a round-trip) and
+# inbound DM wires are held, per the addendum.
 my %own_handle;
 
 # Throttle for the "held — own identity not learned yet" notice, per
-# "<tag>|<nick>", so a chatty peer doesn't flood while we wait for USERHOST.
+# "<tag>|<nick>", so a chatty peer doesn't flood while we wait for the
+# self-WHOIS reply.
 my %own_wait_notice_at;
 
 sub _dbg {
@@ -539,73 +541,54 @@ sub _ctx_for_target {
     return '@' . $handle;
 }
 
-# One RPL_USERHOST (302) entry `nick[*]=[+|-]ident@host` → ($nick, $handle) or
-# (). Mirrors Rust `parse_userhost_reply`: the trailing `*` on the nick marks
-# an oper (stripped), the leading `+`/`-` on the userhost is the away flag
-# (stripped); the handle keeps `~` and any cloak verbatim.
-sub _parse_userhost_entry {
-    my ($entry) = @_;
-    return unless defined $entry && $entry =~ /^(.+?)=(.+)$/;
-    my ($nick, $userhost) = ($1, $2);
-    $nick =~ s/\*+\z//;
-    $userhost =~ s/^[+-]//;
-    return unless length($nick) && index($userhost, '@') > 0;
-    return ($nick, $userhost);
-}
-
 sub _set_own_handle {
-    my ($server, $handle, $rank) = @_;
+    my ($server, $handle) = @_;
     return unless $server && defined $handle && length $handle;
-    $rank //= 2;
     my $tag = $server->{tag} // return;
-    my $cur = $own_handle{$tag};
-    return if $cur && $cur->{rank} > $rank;   # prefix-visible never yields to USERHOST
-    if (!$cur || $cur->{handle} ne $handle || $cur->{rank} != $rank) {
-        $own_handle{$tag} = { handle => $handle, rank => $rank };
-        _dbg("own handle on $tag: $handle (rank $rank)");
+    # Callers pass ONLY prefix-visible values (see the %own_handle comment);
+    # all sources are equal-trust, so the newest write wins.
+    if (($own_handle{$tag} // '') ne $handle) {
+        $own_handle{$tag} = $handle;
+        _dbg("own handle on $tag: $handle");
     }
 }
 
-# Best current view of our own PEER-VISIBLE ident@host, or undef while
-# unknown. Priority: rank-2 store → our own nick on any joined channel's
-# nicklist (irssi keeps it current, incl. CHGHOST) → core's join/396-seeded
-# `$server->{userhost}` → rank-1 store (self-USERHOST; solanum-family ircds
-# answer that with the REAL host, so it is last).
+# Best current view of our own PEER-VISIBLE ident@host, or undef while it is
+# genuinely unknown. Priority: the store → our own nick on any joined
+# channel's nicklist (irssi keeps it current, incl. CHGHOST; promoted into
+# the store on discovery because it vanishes with the last part). There is
+# deliberately NO further fallback: core's `$server->{userhost}` can be stale
+# (not updated on our own CHGHOST) and a self-USERHOST answer can be the
+# non-visible real host — better transiently unknown than a value peers do
+# not see.
 sub _own_handle_for {
     my ($server) = @_;
     return unless $server;
     my $tag = $server->{tag} // '';
-    my $entry = $own_handle{$tag};
-    return $entry->{handle} if $entry && $entry->{rank} >= 2;
+    return $own_handle{$tag} if defined $own_handle{$tag};
     my $nick = $server->{nick} // '';
     if (length $nick) {
         for my $ch (eval { $server->channels() }) {
             my $n = eval { $ch->nick_find($nick) };
             next unless $n && $n->{host};
-            # PROMOTE to the rank-2 store: nicklist values are prefix-visible
-            # (JOIN/WHO/CHGHOST-fed) but VANISH when the last shared channel
-            # is parted — without caching, the next read would fall back to
-            # core's possibly-stale userhost or the rank-1 USERHOST value
-            # (the non-visible REAL host on solanum) and break the
-            # recipient-keyed DM context. Later host changes still win via
-            # the equal-rank JOIN/CHGHOST/396 handlers.
-            _set_own_handle($server, $n->{host}, 2);
+            _set_own_handle($server, $n->{host});
             return $n->{host};
         }
     }
-    return $server->{userhost}
-        if defined $server->{userhost} && length $server->{userhost};
-    return $entry ? $entry->{handle} : undef;
+    return undef;
 }
 
-# ONE-SHOT self-USERHOST to seed our own handle — gated to registration/load
-# events, never per message (the 302 reply is itself a message; a per-message
-# trigger would loop). Mirrors the Rust client's RPL_WELCOME one-shot.
-sub _send_self_userhost {
+# ONE-SHOT self-WHOIS to seed our own handle from RPL_WHOISUSER (311) — the
+# DISPLAYED ident@host, i.e. exactly what peers see in our prefix (a
+# self-USERHOST is NOT equivalent: solanum-family ircds answer it with the
+# real host). Gated to registration/load events, never per message (the
+# reply is itself a message; a per-message trigger would loop). Analog of
+# the Rust client's RPL_WELCOME one-shot.
+sub _send_self_whois {
     my ($server) = @_;
     return unless $server && ($server->{nick} // '') ne '';
-    eval { $server->send_raw('USERHOST ' . $server->{nick}) };
-    _dbg("_send_self_userhost failed on " . ($server->{tag} // '?') . ": $@") if $@;
+    eval { $server->send_raw('WHOIS ' . $server->{nick}) };
+    _dbg("_send_self_whois failed on " . ($server->{tag} // '?') . ": $@") if $@;
 }
 
 # Context that REAL incoming DM sessions live under: `@<own_handle>`
@@ -634,7 +617,7 @@ sub _ctx_variants {
 # Set the trust status of a peer's incoming session(s); returns the count. A
 # DM trust change targets the PEER, not one context string: the real session
 # lives under `@<own>` (which may be UNKNOWN right now, e.g. right after
-# reconnect/reload before USERHOST/JOIN/396 seeds it), the trust marker under
+# reconnect/reload before WHOIS/JOIN/396 seeds it), the trust marker under
 # `@<peer>`, plus possibly stale rows from handle drift — so update EVERY DM
 # row for the handle. Touching only the resolvable context would report
 # success while leaving the trusted `@<own>` session decryptable once the
@@ -1328,7 +1311,7 @@ sub cmd_handshake {
     # DM it is stamped with OUR handle (recipient-keyed) — the peer-keyed $ctx
     # above is only the config key.
     my $kreq_ctx = _incoming_ctx_for($server, $ctx);
-    return _prnt_err($witem, 'own identity not learned yet (waiting for the USERHOST reply) — try again in a moment')
+    return _prnt_err($witem, 'own identity not learned yet (waiting for the WHOIS reply) — try again in a moment')
         unless defined $kreq_ctx;
     my $handle = _resolve_handle_for_command($kr, $nick);
     my $wire = eval { build_keyreq($kr, $kreq_ctx, $handle) };
@@ -1992,7 +1975,7 @@ sub _decrypt_wire_message {
         my $own = _own_handle_for($server);
         unless (defined $own && length $own) {
             # Own handle not learned yet (e.g. right after connect, before the
-            # self-USERHOST reply). Do NOT fall back to `@<sender>` —
+            # self-WHOIS reply). Do NOT fall back to `@<sender>` —
             # decrypting or KEYREQ-ing under it would negotiate the WRONG DM
             # direction. Drop; the peer's next message re-establishes once the
             # handle is known.
@@ -2000,7 +1983,7 @@ sub _decrypt_wire_message {
             if (now_unix() - ($own_wait_notice_at{$wait_key} // 0) >= $KEYREQ_MIN_INTERVAL) {
                 $own_wait_notice_at{$wait_key} = now_unix();
                 _prnt_warn(_notice_witem_for_ctx($server, $nick, $nick),
-                           "encrypted DM from $nick held — own identity not learned yet (waiting for the USERHOST reply)");
+                           "encrypted DM from $nick held — own identity not learned yet (waiting for the WHOIS reply)");
             }
             _dbg("DM wire from $nick but own handle unknown on " . ($server->{tag} // '?'));
             Irssi::signal_stop();
@@ -2066,33 +2049,26 @@ sub _decrypt_wire_message {
 
 # Registration complete: RESET the own handle (the server may assign a
 # different ident/host/cloak this session) and re-seed it with the one-shot
-# self-USERHOST. irssi core also clears `$server->{userhost}` on disconnect,
-# so the fallback never goes stale either.
+# self-WHOIS.
 sub signal_event_001 {
     my ($server, $data, $nick, $address) = @_;
     return unless $server;
     delete $own_handle{ $server->{tag} // '' };
-    _send_self_userhost($server);
+    _send_self_whois($server);
 }
 
-# RPL_USERHOST: seed our own handle from any entry matching our nick (the
-# self-USERHOST on connect, or any later USERHOST that includes us). Rank 1:
-# solanum-family ircds (Libera) answer a SELF-query with the REAL host, not
-# the cloak peers see — this only fills a hole, never overrides a
-# prefix-visible source. Observe-only — never stops the signal (irssi core
-# reads 302 for away flags).
-sub signal_event_302 {
+# RPL_WHOISUSER (311): `$data` = "me nick ident host * :realname" — seed our
+# own handle when the WHOIS is about US. The 311 host is the DISPLAYED
+# (peer-visible) one by definition; the real host travels separately in
+# 338/378, which we never parse. Observe-only — never stops the signal.
+sub signal_event_311 {
     my ($server, $data) = @_;
     return unless $server && defined $data;
-    my ($replies) = $data =~ /:(.*)$/s;
-    $replies //= $data;
-    my $own_nick = lc($server->{nick} // '');
-    return unless length $own_nick;
-    for my $entry (split ' ', $replies) {
-        my ($n, $handle) = _parse_userhost_entry($entry);
-        next unless defined $n && lc($n) eq $own_nick;
-        _set_own_handle($server, $handle, 1);
-    }
+    my (undef, $nick, $ident, $host) = split ' ', $data;
+    return unless defined $nick && defined $ident && defined $host;
+    return unless lc($nick) eq lc($server->{nick} // '');
+    return unless length $ident && length $host;
+    _set_own_handle($server, "$ident\@$host");
 }
 
 # Our own JOIN carries our prefix exactly as peers see it — the strongest
@@ -2103,7 +2079,7 @@ sub signal_event_join_own {
     my ($server, $data, $nick, $address) = @_;
     return unless $server && defined $nick && defined $address && length $address;
     return unless lc($nick) eq lc($server->{nick} // '');
-    _set_own_handle($server, $address, 2);
+    _set_own_handle($server, $address);
 }
 
 # RPL_HOSTHIDDEN (396): the server telling US our new DISPLAYED host —
@@ -2116,12 +2092,12 @@ sub signal_event_396 {
     return unless defined $newhost && length $newhost;
     return if $newhost =~ /[*?!#&\s]/ || $newhost =~ /^[@:\-]/ || $newhost =~ /-$/;
     if (index($newhost, '@') > 0) {
-        _set_own_handle($server, $newhost, 2);
+        _set_own_handle($server, $newhost);
         return;
     }
     my $cur = _own_handle_for($server);
     return unless defined $cur && $cur =~ /^([^@]+)@/;
-    _set_own_handle($server, "$1\@$newhost", 2);
+    _set_own_handle($server, "$1\@$newhost");
 }
 
 # CHGHOST: track our OWN handle (peer handles are read live from prefixes and
@@ -2291,23 +2267,22 @@ Irssi::signal_add_first('ctcp reply RPEE2E', \&signal_ctcp_reply_rpee2e);
 Irssi::signal_add_first('ctcp reply', \&signal_ctcp_reply_generic);
 Irssi::signal_add_first('default ctcp reply', \&signal_default_ctcp_reply_generic);
 # Own-handle tracking for the recipient-keyed DM context
-# (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 302
-# (self-USERHOST reply) and our own CHGHOST. Plain observers — never stop
+# (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 311
+# (self-WHOIS 311 reply — displayed host, exactly what peers see) and our
+# own CHGHOST. Prefix-visible sources ONLY. Plain observers — never stop
 # these signals (irssi core reads 302 for away flags itself).
 Irssi::signal_add('event 001', \&signal_event_001);
-Irssi::signal_add('event 302', \&signal_event_302);
+Irssi::signal_add('event 311', \&signal_event_311);
 Irssi::signal_add('event chghost', \&signal_event_chghost);
 Irssi::signal_add('event join', \&signal_event_join_own);
 Irssi::signal_add('event 396', \&signal_event_396);
 # Script (re)loaded mid-session: `event 001` will not fire for servers that
-# are already up — seed their own handle now. Sent UNCONDITIONALLY: core's
-# `$server->{userhost}` can be stale (it is not updated on own CHGHOST), so
-# skipping when a fallback merely exists would pin the stale value until
-# reconnect. The reply seeds only rank 1, so it can never clobber a
-# prefix-visible value; live nicklist/core lookups still outrank it.
+# are already up — seed their own handle now, unconditionally. The 311 reply
+# is prefix-visible, so at worst it rewrites the store with the same value;
+# users on channels are already covered by the nicklist tier meanwhile.
 for my $server (Irssi::servers()) {
     next unless $server->{connected};
-    _send_self_userhost($server);
+    _send_self_whois($server);
 }
 
 Irssi::print("RPE2E $VERSION loaded — /e2e fingerprint to see your fingerprint");

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -365,6 +365,18 @@ _rate_limit_sent: dict[str, float] = {}
 
 _incoming_buckets: dict[str, "IncomingBucket"] = {}
 
+# Our own server-stamped ident@host, per server — the recipient-keyed DM
+# context (docs/rpe2e-dm-addendum.md): DMs we RECEIVE are keyed `@<own>`.
+# VOLATILE by design (never persisted): reset at (dis)connect and re-seeded via
+# the one-shot self-USERHOST, our own CHGHOST, and echo-message echoes, because
+# the server may assign a different ident/host/cloak each session.
+_own_handle: dict[str, str] = {}
+
+# Throttle for the "held — own identity not learned yet" notice, per
+# (server, sender nick), so a chatty peer doesn't flood the buffer while we
+# wait for the USERHOST reply.
+_own_wait_notice_at: dict[tuple, float] = {}
+
 
 class IncomingBucket:
     __slots__ = ("recent", "backoff_until")
@@ -510,6 +522,54 @@ def context_key(target: str, handle: str) -> str:
     if target and target[0] in CHANNEL_PREFIXES:
         return target
     return "@" + handle
+
+
+def _parse_userhost_reply(entry: str):
+    """One RPL_USERHOST (302) entry `nick[*]=[+|-]ident@host` → (nick, handle)
+    or None. Mirrors Rust `parse_userhost_reply`: the trailing `*` on the nick
+    marks an oper (stripped), the leading `+`/`-` on the userhost is the away
+    flag (stripped); the handle keeps `~` and any cloak verbatim."""
+    if "=" not in entry:
+        return None
+    nick_part, userhost = entry.split("=", 1)
+    nick_part = nick_part.rstrip("*")
+    if userhost[:1] in ("+", "-"):
+        userhost = userhost[1:]
+    if not nick_part or "@" not in userhost:
+        return None
+    return nick_part, userhost
+
+
+def _own_nick(server: str) -> str:
+    return weechat.info_get("irc_nick", server) if weechat else ""
+
+
+def _set_own_handle(server: str, handle: str) -> None:
+    if handle and _own_handle.get(server) != handle:
+        _own_handle[server] = handle
+        _dbg(f"own handle on {server}: {handle}")
+
+
+def _send_self_userhost(server: str) -> None:
+    """ONE-SHOT self-USERHOST to seed our own handle — gated to connect/load
+    events, never per message (the 302 reply is itself a message; a per-message
+    trigger would loop). Mirrors the Rust client's RPL_WELCOME one-shot."""
+    if weechat is None:
+        return
+    nick = _own_nick(server)
+    buf = weechat.buffer_search("irc", f"server.{server}") or ""
+    if nick and buf:
+        weechat.command(buf, f"/quote USERHOST {nick}")
+
+
+def _incoming_ctx_for(server: str, ctx: str):
+    """Context that REAL incoming DM sessions live under: `@<own_handle>`
+    (recipient-keyed — the recipient of the direction is us). Channels pass
+    through unchanged. None → our own handle is not known yet."""
+    if ctx.startswith("@"):
+        own_h = _own_handle.get(server)
+        return ("@" + own_h) if own_h else None
+    return ctx
 
 
 def fingerprint(pk: bytes) -> bytes:
@@ -834,15 +894,6 @@ def _resolve_cached_handle_by_nick(nick: str) -> str | None:
         return None
     matches.sort(key=lambda item: item[0])
     return matches[-1][1]
-
-
-def _ctx_for_target(target: str, handle: str) -> str:
-    """Same as context_key but explicit: channel targets pass through,
-    PM targets become `@<handle>`. Callers that have a real handle (from
-    an inbound message or from a nicklist lookup) pass it here."""
-    if target and target[0] in CHANNEL_PREFIXES:
-        return target
-    return "@" + handle
 
 
 def _ctx_for_command(buffer_ptr, server: str, target: str, nick: str | None) -> str | None:
@@ -1220,7 +1271,23 @@ def _build_keyrsp_for_req(
     return "\x01" + body + "\x01"
 
 
-def _maybe_build_reciprocal_keyreq(channel: str, sender_handle: str) -> str | None:
+def _reciprocal_ctx(channel: str, server: str) -> str | None:
+    """Context for OUR reciprocal KEYREQ. A reciprocal establishes the
+    peer→us direction, whose recipient-keyed context is OUR handle — not the
+    requester's context from their KEYREQ (that names the other direction).
+    Channels pass through. None → own handle unknown; skip the reciprocal
+    (the transport self-heals later via auto-KEYREQ on their first wire)."""
+    if channel[:1] in CHANNEL_PREFIXES:
+        return channel
+    own_h = _own_handle.get(server)
+    return ("@" + own_h) if own_h else None
+
+
+def _maybe_build_reciprocal_keyreq(channel: str, sender_handle: str, server: str) -> str | None:
+    channel = _reciprocal_ctx(channel, server)
+    if channel is None:
+        _dbg("_maybe_build_reciprocal_keyreq: own handle unknown — skipping")
+        return None
     with db_conn() as c:
         row = c.execute(
             "SELECT status FROM incoming WHERE handle = ? AND channel = ?",
@@ -1241,7 +1308,11 @@ def _maybe_build_reciprocal_keyreq(channel: str, sender_handle: str) -> str | No
     return build_keyreq(channel, sender_handle)
 
 
-def _build_reciprocal_keyreq_on_accept(channel: str, sender_handle: str) -> str | None:
+def _build_reciprocal_keyreq_on_accept(channel: str, sender_handle: str, server: str) -> str | None:
+    channel = _reciprocal_ctx(channel, server)
+    if channel is None:
+        _dbg("_build_reciprocal_keyreq_on_accept: own handle unknown — skipping")
+        return None
     with db_conn() as c:
         row = c.execute(
             "SELECT status FROM incoming WHERE handle = ? AND channel = ?",
@@ -1393,7 +1464,7 @@ def handle_keyreq(server: str, sender_handle: str, nick: str, body: str) -> tupl
         req["channel"], sender_handle, req["pub"], req["eph_x25519"]
     )
     _dbg(f"handle_keyreq: _build_keyrsp_for_req returned rsp={'yes' if rsp else 'no'}")
-    reciprocal = _maybe_build_reciprocal_keyreq(req["channel"], sender_handle)
+    reciprocal = _maybe_build_reciprocal_keyreq(req["channel"], sender_handle, server)
     _dbg(f"handle_keyreq: reciprocal={'yes' if reciprocal else 'no'}")
     return rsp, reciprocal
 
@@ -2120,6 +2191,63 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
     return ""
 
 
+def hook_signal_server_connected(data, signal, signal_data):
+    """Registration complete: RESET the own handle (the server may assign a
+    different ident/host/cloak this session) and re-seed it with the one-shot
+    self-USERHOST. `signal_data` is the server name."""
+    try:
+        server = signal_data or ""
+        _own_handle.pop(server, None)
+        _send_self_userhost(server)
+    except Exception as e:
+        _dbg(f"hook_signal_server_connected: {e}")
+    return weechat.WEECHAT_RC_OK if weechat else 0
+
+
+def hook_signal_server_disconnected(data, signal, signal_data):
+    try:
+        _own_handle.pop(signal_data or "", None)
+    except Exception as e:
+        _dbg(f"hook_signal_server_disconnected: {e}")
+    return weechat.WEECHAT_RC_OK if weechat else 0
+
+
+def hook_irc_in_302(data, modifier, server, msg):
+    """RPL_USERHOST: seed our own handle from any entry matching our nick
+    (a self-USERHOST on connect, or any later USERHOST that includes us).
+    Observe-only — the line always passes through unmodified."""
+    try:
+        trailing = msg.split(" :", 1)[1] if " :" in msg else msg.rsplit(" ", 1)[-1]
+        own = _own_nick(server)
+        for entry in trailing.split():
+            parsed = _parse_userhost_reply(entry)
+            if parsed and own and parsed[0].lower() == own.lower():
+                _set_own_handle(server, parsed[1])
+    except Exception as e:
+        _dbg(f"hook_irc_in_302: {e}")
+    return msg
+
+
+def hook_irc_in_chghost(data, modifier, server, msg):
+    """CHGHOST `:nick!old@old CHGHOST newident newhost`: track our OWN handle
+    (peer handles are always read live from prefixes/nicklists). weechat's
+    irc plugin only forwards CHGHOST when the cap is active, so this is a
+    no-op otherwise. Observe-only."""
+    try:
+        if msg.startswith(":"):
+            parts = msg.split(" ")
+            nick = parts[0][1:].split("!", 1)[0]
+            own = _own_nick(server)
+            if own and nick.lower() == own.lower() and len(parts) >= 4:
+                newuser = parts[2]
+                newhost = parts[3].lstrip(":")
+                if newuser and newhost:
+                    _set_own_handle(server, f"{newuser}@{newhost}")
+    except Exception as e:
+        _dbg(f"hook_irc_in_chghost: {e}")
+    return msg
+
+
 def hook_irc_in_privmsg(data, modifier, server, msg):
     try:
         if not msg.startswith(":"):
@@ -2137,9 +2265,22 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         target = rest_parts[1]
         text = rest_parts[2][1:] if rest_parts[2].startswith(":") else rest_parts[2]
 
+        # echo-message: the server echoes our own PRIVMSG back with our
+        # CANONICAL prefix — the freshest own-handle source there is (weechat
+        # requests available caps by default, so this is commonly active).
+        own = _own_nick(server)
+        is_own_echo = bool(own) and nick.lower() == own.lower()
+        if is_own_echo:
+            _set_own_handle(server, handle)
+
         wire = parse_wire(text)
         if wire is None:
             return msg
+        if is_own_echo:
+            # Our own ciphertext echo: the plaintext was already rendered
+            # locally at send time. Swallow it — falling through would treat
+            # it as a peer's wire (decrypt fail → auto-KEYREQ to ourselves).
+            return ""
         _dbg(
             f"hook_irc_in_privmsg RPE2E wire from {nick}!{handle} → {target} "
             f"msgid={wire['msgid'].hex() if isinstance(wire.get('msgid'), bytes) else wire.get('msgid')} "
@@ -2160,9 +2301,31 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         # wrong pick cannot leak — AEAD decrypt just fails); the most-stripped
         # reading stays the default so auto-KEYREQ keeps keying off it.
         readings = _channel_readings(target)
-        ctx_candidates = [context_key(r, handle) for r in readings] or [
-            context_key(target, handle)
-        ]
+        if readings:
+            ctx_candidates = [context_key(r, handle) for r in readings]
+        else:
+            # DM: recipient-keyed context (docs/rpe2e-dm-addendum.md) — WE are
+            # the recipient, so the context is OUR handle, never the sender's.
+            own_h = _own_handle.get(server)
+            if not own_h:
+                # Own handle not learned yet (e.g. right after connect, before
+                # the self-USERHOST reply). Do NOT fall back to `@<sender>` —
+                # decrypting or KEYREQ-ing under it would negotiate the WRONG
+                # DM direction. Drop; the peer's next message re-establishes
+                # once the handle is known.
+                now_f = time.time()
+                wait_key = (server, nick)
+                if now_f - _own_wait_notice_at.get(wait_key, 0.0) >= KEYREQ_MIN_INTERVAL:
+                    _own_wait_notice_at[wait_key] = now_f
+                    buf = weechat.buffer_search("irc", f"{server}.{nick}") if weechat else ""
+                    _prnt_warn(
+                        buf,
+                        f"encrypted DM from {nick} held — own identity not "
+                        "learned yet (waiting for the USERHOST reply)",
+                    )
+                _dbg(f"hook_irc_in_privmsg: DM wire from {nick} but own handle unknown on {server}")
+                return ""
+            ctx_candidates = ["@" + own_h]
         ctx = ctx_candidates[0]
         with db_conn() as c:
             row = c.execute(
@@ -2187,7 +2350,10 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
             now_f = time.time()
             if now_f - last >= KEYREQ_MIN_INTERVAL:
                 _rate_limit_sent[handle] = now_f
-                buf = weechat.buffer_search("irc", f"{server}.{target}") if weechat else ""
+                # For a DM the wire target is OUR nick — the query buffer is
+                # named after the PEER, so search by sender there.
+                buf_name = target if readings else nick
+                buf = weechat.buffer_search("irc", f"{server}.{buf_name}") if weechat else ""
                 try:
                     kreq = build_keyreq(ctx, handle)
                     if weechat:
@@ -2422,10 +2588,19 @@ def cmd_e2e(data, buffer, args):
         if ctx is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
         with db_conn() as c:
-            rows = c.execute(
-                "SELECT handle, channel, fp, status FROM incoming WHERE channel = ?",
-                (ctx,),
-            ).fetchall()
+            if ctx.startswith("@"):
+                # Query buffer: real DM sessions are recipient-keyed under
+                # `@<own>`, trust markers under `@<peer>` — list everything
+                # from this peer regardless of context.
+                rows = c.execute(
+                    "SELECT handle, channel, fp, status FROM incoming WHERE handle = ?",
+                    (ctx[1:],),
+                ).fetchall()
+            else:
+                rows = c.execute(
+                    "SELECT handle, channel, fp, status FROM incoming WHERE channel = ?",
+                    (ctx,),
+                ).fetchall()
         if not rows:
             _prnt_ok(buf, "no peers")
         else:
@@ -2455,7 +2630,7 @@ def cmd_e2e(data, buffer, args):
                     (ctx, s_handle),
                 )
             rsp_wire = _build_keyrsp_for_req(ctx, s_handle, s_pub, s_eph)
-            reciprocal = _build_reciprocal_keyreq_on_accept(ctx, s_handle)
+            reciprocal = _build_reciprocal_keyreq_on_accept(ctx, s_handle, server)
             if rsp_wire is not None and weechat:
                 _send_raw_notice(server, nick, rsp_wire)
             if reciprocal is not None and weechat:
@@ -2504,10 +2679,15 @@ def cmd_e2e(data, buffer, args):
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
         with db_conn() as c:
-            c.execute(
-                "UPDATE incoming SET status='revoked' WHERE handle = ? AND channel = ?",
-                (handle, ctx),
-            )
+            # DM sessions live under two contexts (recipient-keyed): real
+            # incoming sessions under `@<own>`, KEYREQ-direction trust markers
+            # under `@<peer>` (= ctx). Revoke both so inbound decrypt — which
+            # honors only `@<own>` — actually stops trusting the peer.
+            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
+                c.execute(
+                    "UPDATE incoming SET status='revoked' WHERE handle = ? AND channel = ?",
+                    (handle, rctx),
+                )
             c.execute(
                 "DELETE FROM outgoing_recipients WHERE channel = ? AND handle = ?",
                 (ctx, handle),
@@ -2526,10 +2706,12 @@ def cmd_e2e(data, buffer, args):
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
         with db_conn() as c:
-            c.execute(
-                "UPDATE incoming SET status='trusted' WHERE handle = ? AND channel = ?",
-                (handle, ctx),
-            )
+            # Mirror of revoke: restore trust under both DM context forms.
+            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
+                c.execute(
+                    "UPDATE incoming SET status='trusted' WHERE handle = ? AND channel = ?",
+                    (handle, rctx),
+                )
         _prnt_ok(buf, f"unrevoked {nick} on {ctx}")
     elif sub == "forget":
         if not rest:
@@ -2543,10 +2725,12 @@ def cmd_e2e(data, buffer, args):
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
         with db_conn() as c:
-            c.execute(
-                "DELETE FROM incoming WHERE handle = ? AND channel = ?",
-                (handle, ctx),
-            )
+            # Delete both DM context forms (see revoke).
+            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
+                c.execute(
+                    "DELETE FROM incoming WHERE handle = ? AND channel = ?",
+                    (handle, rctx),
+                )
         _prnt_warn(buf, f"forgotten {nick} on {ctx}")
     elif sub == "handshake":
         if not rest:
@@ -2556,8 +2740,22 @@ def cmd_e2e(data, buffer, args):
         ctx = _ctx_or_error(buf, buffer, server, channel, nick, "/e2e handshake")
         if ctx is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
+        # A KEYREQ asks the peer for the key of the direction WE receive, so
+        # for a DM it is stamped with OUR handle (recipient-keyed), not the
+        # peer's context the config is stored under.
+        kreq_ctx = _incoming_ctx_for(server, ctx)
+        if kreq_ctx is None:
+            _prnt_err(
+                buf,
+                "/e2e handshake: own identity not learned yet (waiting for "
+                "the USERHOST reply) — try again in a moment",
+            )
+            return weechat.WEECHAT_RC_OK if weechat else 0
+        # Best-effort peer handle for the pending key; build_keyreq falls back
+        # to a bare-ctx pending row when unresolvable (KEYRSP matches either).
+        s_handle = _resolve_handle_for_command(server, channel, nick)
         try:
-            kreq = build_keyreq(ctx)
+            kreq = build_keyreq(kreq_ctx, s_handle)
         except Exception as e:
             _prnt_err(buf, f"handshake failed: {e}")
             return weechat.WEECHAT_RC_OK if weechat else 0
@@ -2583,10 +2781,17 @@ def cmd_e2e(data, buffer, args):
         local_hex = fingerprint_hex(local_fp)
         local_short = local_hex[:16]
         with db_conn() as c:
-            row = c.execute(
-                "SELECT fp FROM incoming WHERE handle = ? AND channel = ?",
-                (handle, ctx),
-            ).fetchone()
+            # Real DM sessions are recipient-keyed under `@<own>`; fall back
+            # to the peer-keyed trust marker if only that exists.
+            row = None
+            inc_ctx = _incoming_ctx_for(server, ctx)
+            for rctx in [c2 for c2 in (inc_ctx, ctx) if c2]:
+                row = c.execute(
+                    "SELECT fp FROM incoming WHERE handle = ? AND channel = ?",
+                    (handle, rctx),
+                ).fetchone()
+                if row is not None:
+                    break
         if row is None:
             _prnt_err(buf, f"no session for {nick} on {ctx}")
         else:
@@ -2982,6 +3187,21 @@ def main() -> None:
     # Authoritative outbound fail-closed gate (F1): every PRIVMSG on the wire —
     # `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
     weechat.hook_modifier("irc_out1_privmsg", "hook_irc_out_privmsg", "")
+    # Own-handle tracking for the recipient-keyed DM context
+    # (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 302
+    # (self-USERHOST reply) and our own CHGHOST.
+    weechat.hook_signal("irc_server_connected", "hook_signal_server_connected", "")
+    weechat.hook_signal("irc_server_disconnected", "hook_signal_server_disconnected", "")
+    weechat.hook_modifier("irc_in2_302", "hook_irc_in_302", "")
+    weechat.hook_modifier("irc_in2_chghost", "hook_irc_in_chghost", "")
+    # Script (re)loaded mid-session: `irc_server_connected` will not fire for
+    # servers that are already up — seed their own handle now.
+    infolist = weechat.infolist_get("irc_server", "", "")
+    if infolist:
+        while weechat.infolist_next(infolist):
+            if weechat.infolist_integer(infolist, "is_connected") == 1:
+                _send_self_userhost(weechat.infolist_string(infolist, "name"))
+        weechat.infolist_free(infolist)
     weechat.hook_command(
         "e2e",
         SCRIPT_DESC,

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -589,6 +589,15 @@ def _own_handle_get(server: str):
                 finally:
                     weechat.infolist_free(infolist)
                 if found:
+                    # PROMOTE to the rank-2 store: nicklist values are
+                    # prefix-visible (JOIN/WHO/userhost-in-names/CHGHOST-fed)
+                    # but VANISH when the last shared channel is parted —
+                    # without caching, the next read would fall back to the
+                    # rank-1 USERHOST value (the non-visible REAL host on
+                    # solanum) and break the recipient-keyed DM context.
+                    # Later host changes still win via the equal-rank
+                    # JOIN/CHGHOST/396/echo hooks.
+                    _set_own_handle(server, found)
                     return found
     return entry["handle"] if entry else None
 

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -534,6 +534,23 @@ def context_key(target: str, handle: str) -> str:
     return "@" + handle
 
 
+def _split_irc_tags(msg: str):
+    """weechat's `irc_in2_*` modifiers pass the raw line INCLUDING IRCv3
+    message tags (`@time=… :prefix CMD …`) whenever caps like server-time are
+    active (verified in irc-server.c: the modifier gets the full decoded
+    line). Returns (tags_prefix, rest): `tags_prefix` is "" or the tag
+    section INCLUDING its trailing space, so a hook that rewrites the line
+    can re-prepend it verbatim; `rest` starts at the `:prefix`. Every parser
+    here works on the tagless form — without this, `@time=…` lines made the
+    prefix-visible own-handle hooks blind and let hook_irc_in_396 read the
+    wrong token as the new host (poisoning the rank-2 store)."""
+    if msg.startswith("@"):
+        sp = msg.find(" ")
+        if sp > 0:
+            return msg[: sp + 1], msg[sp + 1 :].lstrip(" ")
+    return "", msg
+
+
 def _parse_userhost_reply(entry: str):
     """One RPL_USERHOST (302) entry `nick[*]=[+|-]ident@host` → (nick, handle)
     or None. Mirrors Rust `parse_userhost_reply`: the trailing `*` on the nick
@@ -2312,7 +2329,8 @@ def hook_irc_in_302(data, modifier, server, msg):
     host, not the cloak peers see — so this only fills a hole and never
     overrides a prefix-visible source. Observe-only, line passes through."""
     try:
-        trailing = msg.split(" :", 1)[1] if " :" in msg else msg.rsplit(" ", 1)[-1]
+        _tags, line = _split_irc_tags(msg)
+        trailing = line.split(" :", 1)[1] if " :" in line else line.rsplit(" ", 1)[-1]
         own = _own_nick(server)
         for entry in trailing.split():
             parsed = _parse_userhost_reply(entry)
@@ -2328,8 +2346,9 @@ def hook_irc_in_join(data, modifier, server, msg):
     peers see it — the strongest own-handle source next to echo-message, and
     present right after connect (autojoin). Observe-only."""
     try:
-        if msg.startswith(":"):
-            prefix = msg[1:].split(" ", 1)[0]
+        _tags, line = _split_irc_tags(msg)
+        if line.startswith(":"):
+            prefix = line[1:].split(" ", 1)[0]
             if "!" in prefix and "@" in prefix:
                 nick, userhost = prefix.split("!", 1)
                 own = _own_nick(server)
@@ -2345,8 +2364,12 @@ def hook_irc_in_396(data, modifier, server, msg):
     the server telling US our new DISPLAYED host (peer-visible by
     definition). Host-only form merges with the known ident. Observe-only."""
     try:
-        parts = msg.split(" ")
-        if len(parts) >= 4:
+        _tags, line = _split_irc_tags(msg)
+        parts = line.split(" ")
+        # Field positions are only meaningful on a well-formed
+        # `:server 396 nick <host> …` line — never guess otherwise (a shifted
+        # token here would poison the rank-2 store).
+        if line.startswith(":") and len(parts) >= 4 and parts[1] == "396":
             newhost = parts[3].lstrip(":")
             # mirror irssi core's sanity check on the announced host
             if newhost and not any(c in newhost for c in "*?!# ") and newhost[0] not in "@:-" and not newhost.endswith("-"):
@@ -2367,8 +2390,9 @@ def hook_irc_in_chghost(data, modifier, server, msg):
     irc plugin only forwards CHGHOST when the cap is active, so this is a
     no-op otherwise. Observe-only."""
     try:
-        if msg.startswith(":"):
-            parts = msg.split(" ")
+        _tags, line = _split_irc_tags(msg)
+        if line.startswith(":"):
+            parts = line.split(" ")
             nick = parts[0][1:].split("!", 1)[0]
             own = _own_nick(server)
             if own and nick.lower() == own.lower() and len(parts) >= 4:
@@ -2383,11 +2407,12 @@ def hook_irc_in_chghost(data, modifier, server, msg):
 
 def hook_irc_in_privmsg(data, modifier, server, msg):
     try:
-        if not msg.startswith(":"):
+        tags, line = _split_irc_tags(msg)
+        if not line.startswith(":"):
             return msg
-        prefix_end = msg.index(" ")
-        prefix = msg[1:prefix_end]
-        rest = msg[prefix_end + 1 :]
+        prefix_end = line.index(" ")
+        prefix = line[1:prefix_end]
+        rest = line[prefix_end + 1 :]
         if "!" not in prefix or "@" not in prefix:
             return msg
         nick, userhost = prefix.split("!", 1)
@@ -2521,7 +2546,9 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         if pt_str.startswith("\x01") and not pt_str.startswith("\x01ACTION "):
             _dbg(f"hook_irc_in_privmsg: dropping decrypted non-ACTION CTCP from {nick}")
             return ""
-        return f":{prefix} PRIVMSG {target} :{pt_str}"
+        # Re-prepend the original IRCv3 tags: dropping them would lose
+        # server-time/msgid on the decrypted line.
+        return f"{tags}:{prefix} PRIVMSG {target} :{pt_str}"
     except Exception as e:
         _dbg(f"hook_irc_in_privmsg OUTER EXCEPTION: {e}\n{traceback.format_exc()}")
         return msg
@@ -2590,11 +2617,12 @@ def hook_input_text_for_buffer(data, modifier, modifier_data, text):
 
 def hook_irc_in_notice(data, modifier, server, msg):
     try:
-        if not msg.startswith(":"):
+        _tags, line = _split_irc_tags(msg)
+        if not line.startswith(":"):
             return msg
-        prefix_end = msg.index(" ")
-        prefix = msg[1:prefix_end]
-        rest = msg[prefix_end + 1 :]
+        prefix_end = line.index(" ")
+        prefix = line[1:prefix_end]
+        rest = line[prefix_end + 1 :]
         if "!" not in prefix or "@" not in prefix:
             return msg
         nick, userhost = prefix.split("!", 1)

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -370,21 +370,22 @@ _incoming_buckets: dict[str, "IncomingBucket"] = {}
 # VOLATILE by design (never persisted): reset at (dis)connect and re-seeded,
 # because the server may assign a different ident/host/cloak each session.
 #
-# Sources are RANKED, because they disagree on cloaked networks: what matters
-# is the handle as PEERS see it (our message prefix), and solanum-family ircds
-# (Libera) answer a self-USERHOST with the REAL host, not the cloak.
-#   rank 2 — prefix-visible: echo-message echoes, our own JOIN, our own
-#            CHGHOST, RPL_HOSTHIDDEN (396). Authoritative.
-#   rank 1 — self-USERHOST (302) reply: seed of last resort (a DM-only user
-#            on zero channels produces no rank-2 event until they speak).
-# A lower rank never overwrites a higher one; reads prefer rank 2, then a live
-# own-nicklist lookup (kept current by weechat incl. CHGHOST), then rank 1.
-# Values: {"handle": str, "rank": int}.
-_own_handle: dict[str, dict] = {}
+# ONLY PREFIX-VISIBLE sources are ever stored — values peers themselves see
+# in our message prefix: echo-message echoes, our own JOIN, our own CHGHOST,
+# RPL_HOSTHIDDEN (396), self-WHOIS RPL_WHOISUSER (311 — the DISPLAYED host by
+# definition; solanum reveals the real host only in 338, which we never
+# parse), and the own-nicklist lookup in _own_handle_get. Self-view sources
+# are deliberately NOT used at all: a self-USERHOST on solanum-family ircds
+# (Libera) answers with the REAL host, and ANY tier that can disagree with
+# the prefix breaks the recipient-keyed DM context sooner or later. While no
+# source has fired yet, the handle is simply UNKNOWN (transient — the
+# one-shot self-WHOIS at registration/load answers within a round-trip) and
+# inbound DM wires are held, per the addendum.
+_own_handle: dict[str, str] = {}
 
 # Throttle for the "held — own identity not learned yet" notice, per
 # (server, sender nick), so a chatty peer doesn't flood the buffer while we
-# wait for the USERHOST reply.
+# wait for the self-WHOIS reply.
 _own_wait_notice_at: dict[tuple, float] = {}
 
 
@@ -543,7 +544,7 @@ def _split_irc_tags(msg: str):
     can re-prepend it verbatim; `rest` starts at the `:prefix`. Every parser
     here works on the tagless form — without this, `@time=…` lines made the
     prefix-visible own-handle hooks blind and let hook_irc_in_396 read the
-    wrong token as the new host (poisoning the rank-2 store)."""
+    wrong token as the new host (poisoning the own-handle store)."""
     if msg.startswith("@"):
         sp = msg.find(" ")
         if sp > 0:
@@ -551,44 +552,28 @@ def _split_irc_tags(msg: str):
     return "", msg
 
 
-def _parse_userhost_reply(entry: str):
-    """One RPL_USERHOST (302) entry `nick[*]=[+|-]ident@host` → (nick, handle)
-    or None. Mirrors Rust `parse_userhost_reply`: the trailing `*` on the nick
-    marks an oper (stripped), the leading `+`/`-` on the userhost is the away
-    flag (stripped); the handle keeps `~` and any cloak verbatim."""
-    if "=" not in entry:
-        return None
-    nick_part, userhost = entry.split("=", 1)
-    nick_part = nick_part.rstrip("*")
-    if userhost[:1] in ("+", "-"):
-        userhost = userhost[1:]
-    if not nick_part or "@" not in userhost:
-        return None
-    return nick_part, userhost
-
-
 def _own_nick(server: str) -> str:
     return weechat.info_get("irc_nick", server) if weechat else ""
 
 
-def _set_own_handle(server: str, handle: str, rank: int = 2) -> None:
-    if not handle:
-        return
-    cur = _own_handle.get(server)
-    if cur and cur["rank"] > rank:
-        return  # a prefix-visible value never yields to a self-USERHOST one
-    if not cur or cur["handle"] != handle or cur["rank"] != rank:
-        _own_handle[server] = {"handle": handle, "rank": rank}
-        _dbg(f"own handle on {server}: {handle} (rank {rank})")
+def _set_own_handle(server: str, handle: str) -> None:
+    """Callers pass ONLY prefix-visible values (see the _own_handle comment);
+    all sources are equal-trust, so the newest write wins."""
+    if handle and _own_handle.get(server) != handle:
+        _own_handle[server] = handle
+        _dbg(f"own handle on {server}: {handle}")
 
 
 def _own_handle_get(server: str):
-    """Best current view of our own peer-visible handle, or None.
-    Priority: rank-2 store → our own nick on any joined channel's nicklist
-    (weechat keeps it current, incl. CHGHOST) → rank-1 store (USERHOST)."""
+    """Best current view of our own peer-visible handle, or None while it is
+    genuinely unknown. Priority: the store → our own nick on any joined
+    channel's nicklist (weechat keeps it current, incl. CHGHOST; promoted
+    into the store on discovery because it vanishes with the last part).
+    There is deliberately NO further fallback — better transiently unknown
+    than a value peers do not see."""
     entry = _own_handle.get(server)
-    if entry and entry["rank"] >= 2:
-        return entry["handle"]
+    if entry:
+        return entry
     if weechat is not None:
         nick = _own_nick(server)
         if nick:
@@ -606,29 +591,30 @@ def _own_handle_get(server: str):
                 finally:
                     weechat.infolist_free(infolist)
                 if found:
-                    # PROMOTE to the rank-2 store: nicklist values are
+                    # PROMOTE into the store: nicklist values are
                     # prefix-visible (JOIN/WHO/userhost-in-names/CHGHOST-fed)
                     # but VANISH when the last shared channel is parted —
-                    # without caching, the next read would fall back to the
-                    # rank-1 USERHOST value (the non-visible REAL host on
-                    # solanum) and break the recipient-keyed DM context.
-                    # Later host changes still win via the equal-rank
-                    # JOIN/CHGHOST/396/echo hooks.
+                    # without caching, the handle would go unknown again.
+                    # Later host changes still win via the JOIN/CHGHOST/396/
+                    # echo hooks (newest write wins).
                     _set_own_handle(server, found)
                     return found
-    return entry["handle"] if entry else None
+    return None
 
 
-def _send_self_userhost(server: str) -> None:
-    """ONE-SHOT self-USERHOST to seed our own handle — gated to connect/load
-    events, never per message (the 302 reply is itself a message; a per-message
-    trigger would loop). Mirrors the Rust client's RPL_WELCOME one-shot."""
+def _send_self_whois(server: str) -> None:
+    """ONE-SHOT self-WHOIS to seed our own handle from RPL_WHOISUSER (311) —
+    the DISPLAYED ident@host, i.e. exactly what peers see in our prefix (a
+    self-USERHOST is NOT equivalent: solanum-family ircds answer it with the
+    real host). Gated to connect/load events, never per message (the reply is
+    itself a message; a per-message trigger would loop). Analog of the Rust
+    client's RPL_WELCOME one-shot."""
     if weechat is None:
         return
     nick = _own_nick(server)
     buf = weechat.buffer_search("irc", f"server.{server}") or ""
     if nick and buf:
-        weechat.command(buf, f"/quote USERHOST {nick}")
+        weechat.command(buf, f"/quote WHOIS {nick}")
 
 
 def _incoming_ctx_for(server: str, ctx: str):
@@ -645,7 +631,7 @@ def _update_incoming_trust(handle: str, ctx: str, status: str) -> int:
     """Set the trust status of a peer's incoming session(s); returns the row
     count. A DM trust change targets the PEER, not one context string: the
     real session lives under `@<own>` (which may be UNKNOWN right now, e.g.
-    right after reconnect/reload before USERHOST/JOIN/396 seeds it), the
+    right after reconnect/reload before WHOIS/JOIN/396 seeds it), the
     trust marker under `@<peer>`, plus possibly stale rows from handle drift
     — so update EVERY DM row for the handle. Touching only the resolvable
     context would report success while leaving the trusted `@<own>` session
@@ -2304,11 +2290,11 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
 def hook_signal_server_connected(data, signal, signal_data):
     """Registration complete: RESET the own handle (the server may assign a
     different ident/host/cloak this session) and re-seed it with the one-shot
-    self-USERHOST. `signal_data` is the server name."""
+    self-WHOIS. `signal_data` is the server name."""
     try:
         server = signal_data or ""
         _own_handle.pop(server, None)
-        _send_self_userhost(server)
+        _send_self_whois(server)
     except Exception as e:
         _dbg(f"hook_signal_server_connected: {e}")
     return weechat.WEECHAT_RC_OK if weechat else 0
@@ -2322,22 +2308,21 @@ def hook_signal_server_disconnected(data, signal, signal_data):
     return weechat.WEECHAT_RC_OK if weechat else 0
 
 
-def hook_irc_in_302(data, modifier, server, msg):
-    """RPL_USERHOST: seed our own handle from any entry matching our nick
-    (the self-USERHOST on connect, or any later USERHOST that includes us).
-    Rank 1: solanum-family ircds (Libera) answer a SELF-query with the REAL
-    host, not the cloak peers see — so this only fills a hole and never
-    overrides a prefix-visible source. Observe-only, line passes through."""
+def hook_irc_in_311(data, modifier, server, msg):
+    """RPL_WHOISUSER: `:srv 311 me nick ident host * :realname` — seed our
+    own handle when the WHOIS is about US. The 311 host is the DISPLAYED
+    (peer-visible) one by definition; the real host travels separately in
+    338/378, which we never parse. Observe-only, line passes through."""
     try:
         _tags, line = _split_irc_tags(msg)
-        trailing = line.split(" :", 1)[1] if " :" in line else line.rsplit(" ", 1)[-1]
-        own = _own_nick(server)
-        for entry in trailing.split():
-            parsed = _parse_userhost_reply(entry)
-            if parsed and own and parsed[0].lower() == own.lower():
-                _set_own_handle(server, parsed[1], rank=1)
+        parts = line.split(" ")
+        if line.startswith(":") and len(parts) >= 6 and parts[1] == "311":
+            nick, ident, host = parts[3], parts[4], parts[5]
+            own = _own_nick(server)
+            if own and nick.lower() == own.lower() and ident and host:
+                _set_own_handle(server, f"{ident}@{host}")
     except Exception as e:
-        _dbg(f"hook_irc_in_302: {e}")
+        _dbg(f"hook_irc_in_311: {e}")
     return msg
 
 
@@ -2368,7 +2353,7 @@ def hook_irc_in_396(data, modifier, server, msg):
         parts = line.split(" ")
         # Field positions are only meaningful on a well-formed
         # `:server 396 nick <host> …` line — never guess otherwise (a shifted
-        # token here would poison the rank-2 store).
+        # token here would poison the own-handle store).
         if line.startswith(":") and len(parts) >= 4 and parts[1] == "396":
             newhost = parts[3].lstrip(":")
             # mirror irssi core's sanity check on the announced host
@@ -2467,7 +2452,7 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
             own_h = _own_handle_get(server)
             if not own_h:
                 # Own handle not learned yet (e.g. right after connect, before
-                # the self-USERHOST reply). Do NOT fall back to `@<sender>` —
+                # the self-WHOIS reply). Do NOT fall back to `@<sender>` —
                 # decrypting or KEYREQ-ing under it would negotiate the WRONG
                 # DM direction. Drop; the peer's next message re-establishes
                 # once the handle is known.
@@ -2479,7 +2464,7 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
                     _prnt_warn(
                         buf,
                         f"encrypted DM from {nick} held — own identity not "
-                        "learned yet (waiting for the USERHOST reply)",
+                        "learned yet (waiting for the WHOIS reply)",
                     )
                 _dbg(f"hook_irc_in_privmsg: DM wire from {nick} but own handle unknown on {server}")
                 return ""
@@ -2891,7 +2876,7 @@ def cmd_e2e(data, buffer, args):
             _prnt_err(
                 buf,
                 "/e2e handshake: own identity not learned yet (waiting for "
-                "the USERHOST reply) — try again in a moment",
+                "the WHOIS reply) — try again in a moment",
             )
             return weechat.WEECHAT_RC_OK if weechat else 0
         # Best-effort peer handle for the pending key; build_keyreq falls back
@@ -3331,11 +3316,12 @@ def main() -> None:
     # `/me`, `/msg`, `/say`, `/amsg`, plain input — passes through here.
     weechat.hook_modifier("irc_out1_privmsg", "hook_irc_out_privmsg", "")
     # Own-handle tracking for the recipient-keyed DM context
-    # (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 302
-    # (self-USERHOST reply) and our own CHGHOST.
+    # (docs/rpe2e-dm-addendum.md): reset+reseed at registration, observe 311
+    # (self-WHOIS reply — the displayed host, exactly what peers see) and our
+    # own CHGHOST. Prefix-visible sources ONLY; see the _own_handle comment.
     weechat.hook_signal("irc_server_connected", "hook_signal_server_connected", "")
     weechat.hook_signal("irc_server_disconnected", "hook_signal_server_disconnected", "")
-    weechat.hook_modifier("irc_in2_302", "hook_irc_in_302", "")
+    weechat.hook_modifier("irc_in2_311", "hook_irc_in_311", "")
     weechat.hook_modifier("irc_in2_chghost", "hook_irc_in_chghost", "")
     weechat.hook_modifier("irc_in2_join", "hook_irc_in_join", "")
     weechat.hook_modifier("irc_in2_396", "hook_irc_in_396", "")
@@ -3345,7 +3331,7 @@ def main() -> None:
     if infolist:
         while weechat.infolist_next(infolist):
             if weechat.infolist_integer(infolist, "is_connected") == 1:
-                _send_self_userhost(weechat.infolist_string(infolist, "name"))
+                _send_self_whois(weechat.infolist_string(infolist, "name"))
         weechat.infolist_free(infolist)
     weechat.hook_command(
         "e2e",

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -28,6 +28,7 @@ import os
 import sqlite3
 import struct
 import time
+import datetime
 import fnmatch
 import collections
 import traceback
@@ -387,6 +388,51 @@ _own_handle: dict[str, str] = {}
 # (server, sender nick), so a chatty peer doesn't flood the buffer while we
 # wait for the self-WHOIS reply.
 _own_wait_notice_at: dict[tuple, float] = {}
+
+# Wire bodies THIS client sent recently (body → ts), for echo correlation.
+# An own-prefix inbound wire matching this set is our live echo-message echo
+# (prefix trustworthy, plaintext already rendered → swallow); one that does
+# NOT match is a bouncer relay from another attached client or fresh
+# playback — never a handle source, and decrypted with our OWN outgoing key
+# instead of being swallowed. Nick equality alone cannot tell these apart.
+_recent_sent_wires: dict[str, float] = {}
+_SENT_WIRE_TTL = 300.0
+_SENT_WIRE_MAX = 512
+
+
+def _note_sent_wire(body: str) -> None:
+    now_f = time.time()
+    if len(_recent_sent_wires) >= _SENT_WIRE_MAX:
+        for k, ts in list(_recent_sent_wires.items()):
+            if now_f - ts > _SENT_WIRE_TTL:
+                del _recent_sent_wires[k]
+    if len(_recent_sent_wires) < _SENT_WIRE_MAX:
+        _recent_sent_wires[body] = now_f
+
+
+def _take_sent_wire(body: str) -> bool:
+    ts = _recent_sent_wires.pop(body, None)
+    return ts is not None and time.time() - ts <= _SENT_WIRE_TTL
+
+
+def _tags_suggest_replay(tags: str) -> bool:
+    """True when an IRCv3 tag section marks the line as NOT a live echo: a
+    `batch` tag (chathistory / znc.in/playback) or a `time` stamp far from
+    now. Unparseable time stamps count as replay — when in doubt, do not
+    treat the line's prefix as our current handle."""
+    if not tags:
+        return False
+    for t in tags[1:].strip().split(";"):
+        if t.startswith("batch="):
+            return True
+        if t.startswith("time="):
+            val = t[5:].replace("Z", "+00:00")
+            try:
+                ts = datetime.datetime.fromisoformat(val).timestamp()
+            except (ValueError, OverflowError):
+                return True
+            return abs(time.time() - ts) > 120
+    return False
 
 
 class IncomingBucket:
@@ -1126,6 +1172,10 @@ def _send_raw_notice(server: str, nick: str, ctcp_body: str) -> bool:
 def _send_raw_privmsg(server: str, target: str, body: str) -> bool:
     if weechat is None:
         return False
+    # Every wire this client emits goes through here — record it so an
+    # own-prefix inbound copy can be correlated as OUR live echo (vs a
+    # bouncer relay from another attached client / playback).
+    _note_sent_wire(body)
     buf = weechat.buffer_search("irc", f"server.{server}") or ""
     if not buf:
         infolist = weechat.infolist_get("buffer", "", "")
@@ -2390,6 +2440,46 @@ def hook_irc_in_chghost(data, modifier, server, msg):
     return msg
 
 
+def _decrypt_own_copy(server: str, tags: str, prefix: str, target: str, wire) -> str:
+    """Render a copy of OUR OWN message that arrived from outside this client
+    (another attached bouncer client, or fresh playback): decrypt it with our
+    own OUTGOING key for the conversation. `target` is the RECIPIENT (channel
+    or peer nick). Undecryptable (rotated key, unknown peer) → drop with a
+    debug line — never fall through to the peer path (whose failure mode is
+    an auto-KEYREQ to ourselves)."""
+    readings = _channel_readings(target)
+    if readings:
+        ctxs = readings
+    else:
+        h = _resolve_handle_for_command(server, target, target)
+        if not h:
+            _dbg(f"_decrypt_own_copy: cannot resolve peer handle for {target} — dropped")
+            return ""
+        ctxs = ["@" + h]
+    with db_conn() as c:
+        for ctx in ctxs:
+            row = c.execute(
+                "SELECT sk FROM outgoing WHERE channel = ?", (ctx,)
+            ).fetchone()
+            if row is None:
+                continue
+            aad = build_aad(ctx, wire["msgid"], wire["ts"], wire["part"], wire["total"])
+            pt = aead_decrypt(row[0], wire["nonce"], aad, wire["ct"])
+            if pt is None:
+                continue
+            try:
+                pt_str = pt.decode("utf-8")
+            except UnicodeDecodeError:
+                pt_str = pt.decode("utf-8", errors="replace")
+            # Same guard as the peer path: never re-inject a decrypted
+            # non-ACTION CTCP into weechat's pipeline.
+            if pt_str.startswith("\x01") and not pt_str.startswith("\x01ACTION "):
+                return ""
+            return f"{tags}:{prefix} PRIVMSG {target} :{pt_str}"
+    _dbg(f"_decrypt_own_copy: no matching outgoing key for {target} (rotated?) — dropped")
+    return ""
+
+
 def hook_irc_in_privmsg(data, modifier, server, msg):
     try:
         tags, line = _split_irc_tags(msg)
@@ -2408,22 +2498,23 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         target = rest_parts[1]
         text = rest_parts[2][1:] if rest_parts[2].startswith(":") else rest_parts[2]
 
-        # echo-message: the server echoes our own PRIVMSG back with our
-        # CANONICAL prefix — the freshest own-handle source there is (weechat
-        # requests available caps by default, so this is commonly active).
+        # Our nick in the prefix is NOT proof of a live echo: behind a
+        # bouncer the same shape arrives for messages sent by ANOTHER
+        # attached client, and history playback replays our old lines with
+        # the HISTORICAL prefix. Handle capture and swallowing are therefore
+        # gated below on correlation/freshness, never on nick equality alone.
         own = _own_nick(server)
-        is_own_echo = bool(own) and nick.lower() == own.lower()
-        if is_own_echo:
-            _set_own_handle(server, handle)
+        is_own_prefix = bool(own) and nick.lower() == own.lower()
 
         wire = parse_wire(text)
         if wire is None:
+            # Plaintext own-prefix line: a live echo-message echo carries our
+            # CANONICAL current prefix — the freshest own-handle source there
+            # is — but a replayed one (batch / stale server-time) carries a
+            # historical host and would poison the store.
+            if is_own_prefix and not _tags_suggest_replay(tags):
+                _set_own_handle(server, handle)
             return msg
-        if is_own_echo:
-            # Our own ciphertext echo: the plaintext was already rendered
-            # locally at send time. Swallow it — falling through would treat
-            # it as a peer's wire (decrypt fail → auto-KEYREQ to ourselves).
-            return ""
         _dbg(
             f"hook_irc_in_privmsg RPE2E wire from {nick}!{handle} → {target} "
             f"msgid={wire['msgid'].hex() if isinstance(wire.get('msgid'), bytes) else wire.get('msgid')} "
@@ -2434,6 +2525,20 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         skew = abs(int(time.time()) - wire["ts"])
         if skew > TS_TOLERANCE:
             return ""
+        if is_own_prefix:
+            if _take_sent_wire(text):
+                # Correlated with a wire THIS client just sent: a live
+                # echo-message echo. Its prefix is our current canonical
+                # handle (capture), and the plaintext was already rendered
+                # locally at send time (swallow).
+                _set_own_handle(server, handle)
+                return ""
+            # Our nick, but not something we sent: another attached client
+            # behind a bouncer, or fresh playback (older replays were just
+            # dropped by the ts-skew check). Never a handle source, never an
+            # auto-KEYREQ target (ourselves) — decrypt with OUR outgoing key
+            # so the copy renders instead of disappearing.
+            return _decrypt_own_copy(server, tags, prefix, target, wire)
         # STATUSMSG delivery (`@#chan`): the decrypt context is the underlying
         # channel, mirroring the outbound gate. Keep the original `target` for
         # the reconstructed PRIVMSG line so weechat routes it unchanged; only

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -615,6 +615,47 @@ def _incoming_ctx_for(server: str, ctx: str):
     return ctx
 
 
+def _update_incoming_trust(handle: str, ctx: str, status: str) -> int:
+    """Set the trust status of a peer's incoming session(s); returns the row
+    count. A DM trust change targets the PEER, not one context string: the
+    real session lives under `@<own>` (which may be UNKNOWN right now, e.g.
+    right after reconnect/reload before USERHOST/JOIN/396 seeds it), the
+    trust marker under `@<peer>`, plus possibly stale rows from handle drift
+    — so update EVERY DM row for the handle. Touching only the resolvable
+    context would report success while leaving the trusted `@<own>` session
+    decryptable once the handle is learned. Channels update exactly
+    (handle, ctx)."""
+    with db_conn() as c:
+        if ctx.startswith("@"):
+            cur = c.execute(
+                "UPDATE incoming SET status=? WHERE handle = ? AND channel LIKE '@%'",
+                (status, handle),
+            )
+        else:
+            cur = c.execute(
+                "UPDATE incoming SET status=? WHERE handle = ? AND channel = ?",
+                (status, handle, ctx),
+            )
+        return cur.rowcount
+
+
+def _delete_incoming_rows(handle: str, ctx: str) -> int:
+    """Forget a peer's incoming session(s); same handle-wide DM semantics as
+    `_update_incoming_trust` (see there for why)."""
+    with db_conn() as c:
+        if ctx.startswith("@"):
+            cur = c.execute(
+                "DELETE FROM incoming WHERE handle = ? AND channel LIKE '@%'",
+                (handle,),
+            )
+        else:
+            cur = c.execute(
+                "DELETE FROM incoming WHERE handle = ? AND channel = ?",
+                (handle, ctx),
+            )
+        return cur.rowcount
+
+
 def fingerprint(pk: bytes) -> bytes:
     return hashlib.sha256(b"RPE2E01-FP:" + pk).digest()[:16]
 
@@ -2761,16 +2802,8 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e revoke")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
+        _update_incoming_trust(handle, ctx, "revoked")
         with db_conn() as c:
-            # DM sessions live under two contexts (recipient-keyed): real
-            # incoming sessions under `@<own>`, KEYREQ-direction trust markers
-            # under `@<peer>` (= ctx). Revoke both so inbound decrypt — which
-            # honors only `@<own>` — actually stops trusting the peer.
-            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
-                c.execute(
-                    "UPDATE incoming SET status='revoked' WHERE handle = ? AND channel = ?",
-                    (handle, rctx),
-                )
             c.execute(
                 "DELETE FROM outgoing_recipients WHERE channel = ? AND handle = ?",
                 (ctx, handle),
@@ -2788,13 +2821,8 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e unrevoke")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
-        with db_conn() as c:
-            # Mirror of revoke: restore trust under both DM context forms.
-            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
-                c.execute(
-                    "UPDATE incoming SET status='trusted' WHERE handle = ? AND channel = ?",
-                    (handle, rctx),
-                )
+        # Mirror of revoke: handle-wide for DMs (see _update_incoming_trust).
+        _update_incoming_trust(handle, ctx, "trusted")
         _prnt_ok(buf, f"unrevoked {nick} on {ctx}")
     elif sub == "forget":
         if not rest:
@@ -2807,13 +2835,8 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e forget")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
-        with db_conn() as c:
-            # Delete both DM context forms (see revoke).
-            for rctx in {ctx, _incoming_ctx_for(server, ctx) or ctx}:
-                c.execute(
-                    "DELETE FROM incoming WHERE handle = ? AND channel = ?",
-                    (handle, rctx),
-                )
+        # Handle-wide for DMs (see _update_incoming_trust for why).
+        _delete_incoming_rows(handle, ctx)
         _prnt_warn(buf, f"forgotten {nick} on {ctx}")
     elif sub == "handshake":
         if not rest:

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -367,10 +367,20 @@ _incoming_buckets: dict[str, "IncomingBucket"] = {}
 
 # Our own server-stamped ident@host, per server — the recipient-keyed DM
 # context (docs/rpe2e-dm-addendum.md): DMs we RECEIVE are keyed `@<own>`.
-# VOLATILE by design (never persisted): reset at (dis)connect and re-seeded via
-# the one-shot self-USERHOST, our own CHGHOST, and echo-message echoes, because
-# the server may assign a different ident/host/cloak each session.
-_own_handle: dict[str, str] = {}
+# VOLATILE by design (never persisted): reset at (dis)connect and re-seeded,
+# because the server may assign a different ident/host/cloak each session.
+#
+# Sources are RANKED, because they disagree on cloaked networks: what matters
+# is the handle as PEERS see it (our message prefix), and solanum-family ircds
+# (Libera) answer a self-USERHOST with the REAL host, not the cloak.
+#   rank 2 — prefix-visible: echo-message echoes, our own JOIN, our own
+#            CHGHOST, RPL_HOSTHIDDEN (396). Authoritative.
+#   rank 1 — self-USERHOST (302) reply: seed of last resort (a DM-only user
+#            on zero channels produces no rank-2 event until they speak).
+# A lower rank never overwrites a higher one; reads prefer rank 2, then a live
+# own-nicklist lookup (kept current by weechat incl. CHGHOST), then rank 1.
+# Values: {"handle": str, "rank": int}.
+_own_handle: dict[str, dict] = {}
 
 # Throttle for the "held — own identity not learned yet" notice, per
 # (server, sender nick), so a chatty peer doesn't flood the buffer while we
@@ -544,10 +554,43 @@ def _own_nick(server: str) -> str:
     return weechat.info_get("irc_nick", server) if weechat else ""
 
 
-def _set_own_handle(server: str, handle: str) -> None:
-    if handle and _own_handle.get(server) != handle:
-        _own_handle[server] = handle
-        _dbg(f"own handle on {server}: {handle}")
+def _set_own_handle(server: str, handle: str, rank: int = 2) -> None:
+    if not handle:
+        return
+    cur = _own_handle.get(server)
+    if cur and cur["rank"] > rank:
+        return  # a prefix-visible value never yields to a self-USERHOST one
+    if not cur or cur["handle"] != handle or cur["rank"] != rank:
+        _own_handle[server] = {"handle": handle, "rank": rank}
+        _dbg(f"own handle on {server}: {handle} (rank {rank})")
+
+
+def _own_handle_get(server: str):
+    """Best current view of our own peer-visible handle, or None.
+    Priority: rank-2 store → our own nick on any joined channel's nicklist
+    (weechat keeps it current, incl. CHGHOST) → rank-1 store (USERHOST)."""
+    entry = _own_handle.get(server)
+    if entry and entry["rank"] >= 2:
+        return entry["handle"]
+    if weechat is not None:
+        nick = _own_nick(server)
+        if nick:
+            infolist = weechat.infolist_get("irc_channel", "", server)
+            if infolist:
+                found = None
+                try:
+                    while weechat.infolist_next(infolist):
+                        chan = weechat.infolist_string(infolist, "name") or ""
+                        if not chan:
+                            continue
+                        found = _resolve_handle_by_nick(server, chan, nick)
+                        if found:
+                            break
+                finally:
+                    weechat.infolist_free(infolist)
+                if found:
+                    return found
+    return entry["handle"] if entry else None
 
 
 def _send_self_userhost(server: str) -> None:
@@ -567,7 +610,7 @@ def _incoming_ctx_for(server: str, ctx: str):
     (recipient-keyed — the recipient of the direction is us). Channels pass
     through unchanged. None → our own handle is not known yet."""
     if ctx.startswith("@"):
-        own_h = _own_handle.get(server)
+        own_h = _own_handle_get(server)
         return ("@" + own_h) if own_h else None
     return ctx
 
@@ -1279,7 +1322,7 @@ def _reciprocal_ctx(channel: str, server: str) -> str | None:
     (the transport self-heals later via auto-KEYREQ on their first wire)."""
     if channel[:1] in CHANNEL_PREFIXES:
         return channel
-    own_h = _own_handle.get(server)
+    own_h = _own_handle_get(server)
     return ("@" + own_h) if own_h else None
 
 
@@ -2214,17 +2257,57 @@ def hook_signal_server_disconnected(data, signal, signal_data):
 
 def hook_irc_in_302(data, modifier, server, msg):
     """RPL_USERHOST: seed our own handle from any entry matching our nick
-    (a self-USERHOST on connect, or any later USERHOST that includes us).
-    Observe-only — the line always passes through unmodified."""
+    (the self-USERHOST on connect, or any later USERHOST that includes us).
+    Rank 1: solanum-family ircds (Libera) answer a SELF-query with the REAL
+    host, not the cloak peers see — so this only fills a hole and never
+    overrides a prefix-visible source. Observe-only, line passes through."""
     try:
         trailing = msg.split(" :", 1)[1] if " :" in msg else msg.rsplit(" ", 1)[-1]
         own = _own_nick(server)
         for entry in trailing.split():
             parsed = _parse_userhost_reply(entry)
             if parsed and own and parsed[0].lower() == own.lower():
-                _set_own_handle(server, parsed[1])
+                _set_own_handle(server, parsed[1], rank=1)
     except Exception as e:
         _dbg(f"hook_irc_in_302: {e}")
+    return msg
+
+
+def hook_irc_in_join(data, modifier, server, msg):
+    """Our own JOIN (`:nick!ident@host JOIN :#chan`) carries our prefix as
+    peers see it — the strongest own-handle source next to echo-message, and
+    present right after connect (autojoin). Observe-only."""
+    try:
+        if msg.startswith(":"):
+            prefix = msg[1:].split(" ", 1)[0]
+            if "!" in prefix and "@" in prefix:
+                nick, userhost = prefix.split("!", 1)
+                own = _own_nick(server)
+                if own and nick.lower() == own.lower():
+                    _set_own_handle(server, userhost)
+    except Exception as e:
+        _dbg(f"hook_irc_in_join: {e}")
+    return msg
+
+
+def hook_irc_in_396(data, modifier, server, msg):
+    """RPL_HOSTHIDDEN: `:srv 396 nick <host|user@host> :is now your ...` —
+    the server telling US our new DISPLAYED host (peer-visible by
+    definition). Host-only form merges with the known ident. Observe-only."""
+    try:
+        parts = msg.split(" ")
+        if len(parts) >= 4:
+            newhost = parts[3].lstrip(":")
+            # mirror irssi core's sanity check on the announced host
+            if newhost and not any(c in newhost for c in "*?!# ") and newhost[0] not in "@:-" and not newhost.endswith("-"):
+                if "@" in newhost:
+                    _set_own_handle(server, newhost)
+                else:
+                    cur = _own_handle_get(server)
+                    if cur and "@" in cur:
+                        _set_own_handle(server, cur.split("@", 1)[0] + "@" + newhost)
+    except Exception as e:
+        _dbg(f"hook_irc_in_396: {e}")
     return msg
 
 
@@ -2306,7 +2389,7 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         else:
             # DM: recipient-keyed context (docs/rpe2e-dm-addendum.md) — WE are
             # the recipient, so the context is OUR handle, never the sender's.
-            own_h = _own_handle.get(server)
+            own_h = _own_handle_get(server)
             if not own_h:
                 # Own handle not learned yet (e.g. right after connect, before
                 # the self-USERHOST reply). Do NOT fall back to `@<sender>` —
@@ -3194,6 +3277,8 @@ def main() -> None:
     weechat.hook_signal("irc_server_disconnected", "hook_signal_server_disconnected", "")
     weechat.hook_modifier("irc_in2_302", "hook_irc_in_302", "")
     weechat.hook_modifier("irc_in2_chghost", "hook_irc_in_chghost", "")
+    weechat.hook_modifier("irc_in2_join", "hook_irc_in_join", "")
+    weechat.hook_modifier("irc_in2_396", "hook_irc_in_396", "")
     # Script (re)loaded mid-session: `irc_server_connected` will not fire for
     # servers that are already up — seed their own handle now.
     infolist = weechat.infolist_get("irc_server", "", "")

--- a/scripts/weechat/rpe2e.py
+++ b/scripts/weechat/rpe2e.py
@@ -28,7 +28,6 @@ import os
 import sqlite3
 import struct
 import time
-import datetime
 import fnmatch
 import collections
 import traceback
@@ -389,50 +388,31 @@ _own_handle: dict[str, str] = {}
 # wait for the self-WHOIS reply.
 _own_wait_notice_at: dict[tuple, float] = {}
 
-# Wire bodies THIS client sent recently (body → ts), for echo correlation.
-# An own-prefix inbound wire matching this set is our live echo-message echo
-# (prefix trustworthy, plaintext already rendered → swallow); one that does
-# NOT match is a bouncer relay from another attached client or fresh
-# playback — never a handle source, and decrypted with our OWN outgoing key
-# instead of being swallowed. Nick equality alone cannot tell these apart.
-_recent_sent_wires: dict[str, float] = {}
-_SENT_WIRE_TTL = 300.0
-_SENT_WIRE_MAX = 512
+# PRIVMSG bodies THIS client sent recently (body → ts) — wires AND plaintext
+# — for echo correlation. An own-prefix inbound line matching this set is our
+# live echo-message echo: the ONLY situation in which the prefix is
+# trustworthy as our current handle. A non-matching own-prefix line is a
+# bouncer relay from another attached client or playback (tagged or not) —
+# never a handle source. Nick equality alone cannot tell these apart, and
+# tag heuristics cannot either (dumb playback carries no batch/server-time).
+_recent_sent_bodies: dict[str, float] = {}
+_SENT_BODY_TTL = 300.0
+_SENT_BODY_MAX = 512
 
 
-def _note_sent_wire(body: str) -> None:
+def _note_sent_body(body: str) -> None:
     now_f = time.time()
-    if len(_recent_sent_wires) >= _SENT_WIRE_MAX:
-        for k, ts in list(_recent_sent_wires.items()):
-            if now_f - ts > _SENT_WIRE_TTL:
-                del _recent_sent_wires[k]
-    if len(_recent_sent_wires) < _SENT_WIRE_MAX:
-        _recent_sent_wires[body] = now_f
+    if len(_recent_sent_bodies) >= _SENT_BODY_MAX:
+        for k, ts in list(_recent_sent_bodies.items()):
+            if now_f - ts > _SENT_BODY_TTL:
+                del _recent_sent_bodies[k]
+    if len(_recent_sent_bodies) < _SENT_BODY_MAX:
+        _recent_sent_bodies[body] = now_f
 
 
-def _take_sent_wire(body: str) -> bool:
-    ts = _recent_sent_wires.pop(body, None)
-    return ts is not None and time.time() - ts <= _SENT_WIRE_TTL
-
-
-def _tags_suggest_replay(tags: str) -> bool:
-    """True when an IRCv3 tag section marks the line as NOT a live echo: a
-    `batch` tag (chathistory / znc.in/playback) or a `time` stamp far from
-    now. Unparseable time stamps count as replay — when in doubt, do not
-    treat the line's prefix as our current handle."""
-    if not tags:
-        return False
-    for t in tags[1:].strip().split(";"):
-        if t.startswith("batch="):
-            return True
-        if t.startswith("time="):
-            val = t[5:].replace("Z", "+00:00")
-            try:
-                ts = datetime.datetime.fromisoformat(val).timestamp()
-            except (ValueError, OverflowError):
-                return True
-            return abs(time.time() - ts) > 120
-    return False
+def _take_sent_body(body: str) -> bool:
+    ts = _recent_sent_bodies.pop(body, None)
+    return ts is not None and time.time() - ts <= _SENT_BODY_TTL
 
 
 class IncomingBucket:
@@ -673,45 +653,60 @@ def _incoming_ctx_for(server: str, ctx: str):
     return ctx
 
 
-def _update_incoming_trust(handle: str, ctx: str, status: str) -> int:
+def _update_incoming_trust(handle: str, ctx: str, status: str, own_ctx=None) -> int:
     """Set the trust status of a peer's incoming session(s); returns the row
-    count. A DM trust change targets the PEER, not one context string: the
-    real session lives under `@<own>` (which may be UNKNOWN right now, e.g.
-    right after reconnect/reload before WHOIS/JOIN/396 seeds it), the
-    trust marker under `@<peer>`, plus possibly stale rows from handle drift
-    — so update EVERY DM row for the handle. Touching only the resolvable
-    context would report success while leaving the trusted `@<own>` session
-    decryptable once the handle is learned. Channels update exactly
-    (handle, ctx)."""
+    count. A DM trust change touches EXACTLY this server's two context forms:
+    the real session under `@<own>` (`own_ctx`, resolved by the caller —
+    which REFUSES the command while the own handle is unknown, a transient
+    one-WHOIS-round-trip state) and the `@<peer>` trust marker (`ctx`).
+    Never wider: the store has no network column (F3, deferred), so a
+    handle-wide predicate would silently mutate the SAME peer's DM state on
+    OTHER connected networks. This matches the Rust client, whose trust
+    commands operate on `current_e2e_own_context` and error out without it.
+    Known shared residual (Rust has it too, F3 subsumes): rows under a
+    long-gone `@<old own>` from handle drift are not touched. Channels
+    update exactly (handle, ctx)."""
+    ctxs = {ctx, own_ctx} - {None}
     with db_conn() as c:
-        if ctx.startswith("@"):
-            cur = c.execute(
-                "UPDATE incoming SET status=? WHERE handle = ? AND channel LIKE '@%'",
-                (status, handle),
-            )
-        else:
-            cur = c.execute(
+        n = 0
+        for rctx in ctxs:
+            n += c.execute(
                 "UPDATE incoming SET status=? WHERE handle = ? AND channel = ?",
-                (status, handle, ctx),
-            )
-        return cur.rowcount
+                (status, handle, rctx),
+            ).rowcount
+        return n
 
 
-def _delete_incoming_rows(handle: str, ctx: str) -> int:
-    """Forget a peer's incoming session(s); same handle-wide DM semantics as
-    `_update_incoming_trust` (see there for why)."""
+def _own_ctx_or_none(buf: str, server: str, ctx: str, cmd: str):
+    """The `@<own>` context a DM trust change on THIS server must also touch.
+    Channels: the ctx itself. DMs with the own handle still unknown: print
+    the refusal (the state is transient — one WHOIS round-trip) and return
+    None; guessing or going handle-wide would either miss the real session
+    or mutate other networks' rows (see _update_incoming_trust)."""
+    if not ctx.startswith("@"):
+        return ctx
+    own_ctx = _incoming_ctx_for(server, ctx)
+    if own_ctx is None:
+        _prnt_err(
+            buf,
+            f"{cmd}: own identity not learned yet (waiting for the WHOIS "
+            "reply) — try again in a moment",
+        )
+    return own_ctx
+
+
+def _delete_incoming_rows(handle: str, ctx: str, own_ctx=None) -> int:
+    """Forget a peer's incoming session(s); same exact-context DM semantics
+    as `_update_incoming_trust` (see there for why)."""
+    ctxs = {ctx, own_ctx} - {None}
     with db_conn() as c:
-        if ctx.startswith("@"):
-            cur = c.execute(
-                "DELETE FROM incoming WHERE handle = ? AND channel LIKE '@%'",
-                (handle,),
-            )
-        else:
-            cur = c.execute(
+        n = 0
+        for rctx in ctxs:
+            n += c.execute(
                 "DELETE FROM incoming WHERE handle = ? AND channel = ?",
-                (handle, ctx),
-            )
-        return cur.rowcount
+                (handle, rctx),
+            ).rowcount
+        return n
 
 
 def fingerprint(pk: bytes) -> bytes:
@@ -1175,7 +1170,7 @@ def _send_raw_privmsg(server: str, target: str, body: str) -> bool:
     # Every wire this client emits goes through here — record it so an
     # own-prefix inbound copy can be correlated as OUR live echo (vs a
     # bouncer relay from another attached client / playback).
-    _note_sent_wire(body)
+    _note_sent_body(body)
     buf = weechat.buffer_search("irc", f"server.{server}") or ""
     if not buf:
         infolist = weechat.infolist_get("buffer", "", "")
@@ -2306,8 +2301,13 @@ def hook_irc_out_privmsg(data, modifier, server, msg):
 
     action, payload = _e2e_gate_wire(server, target, body)
     if action == "pass":
+        # Plaintext going out: record it for echo correlation (see
+        # _recent_sent_bodies) — a live echo-message echo of this body is the
+        # only own-prefix line whose prefix may seed our own handle.
+        _note_sent_body(body)
         return msg
     if action == "bypass":
+        _note_sent_body(body)
         if payload:
             _prnt_warn(_target_buffer(server, target), payload)
         return msg
@@ -2508,11 +2508,13 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
 
         wire = parse_wire(text)
         if wire is None:
-            # Plaintext own-prefix line: a live echo-message echo carries our
-            # CANONICAL current prefix — the freshest own-handle source there
-            # is — but a replayed one (batch / stale server-time) carries a
-            # historical host and would poison the store.
-            if is_own_prefix and not _tags_suggest_replay(tags):
+            # Plaintext own-prefix line: capture the handle ONLY when it
+            # correlates with a body this client just sent — a live
+            # echo-message echo carries our CANONICAL current prefix, the
+            # freshest own-handle source there is. Uncorrelated copies
+            # (another attached client, playback with or without tags) carry
+            # a prefix we cannot vouch for and would poison the store.
+            if is_own_prefix and _take_sent_body(text):
                 _set_own_handle(server, handle)
             return msg
         _dbg(
@@ -2526,7 +2528,7 @@ def hook_irc_in_privmsg(data, modifier, server, msg):
         if skew > TS_TOLERANCE:
             return ""
         if is_own_prefix:
-            if _take_sent_wire(text):
+            if _take_sent_body(text):
                 # Correlated with a wire THIS client just sent: a live
                 # echo-message echo. Its prefix is our current canonical
                 # handle (capture), and the plaintext was already rendered
@@ -2929,7 +2931,10 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e revoke")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
-        _update_incoming_trust(handle, ctx, "revoked")
+        own_ctx = _own_ctx_or_none(buf, server, ctx, "/e2e revoke")
+        if own_ctx is None:
+            return weechat.WEECHAT_RC_OK if weechat else 0
+        _update_incoming_trust(handle, ctx, "revoked", own_ctx)
         with db_conn() as c:
             c.execute(
                 "DELETE FROM outgoing_recipients WHERE channel = ? AND handle = ?",
@@ -2948,8 +2953,11 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e unrevoke")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
-        # Mirror of revoke: handle-wide for DMs (see _update_incoming_trust).
-        _update_incoming_trust(handle, ctx, "trusted")
+        # Mirror of revoke: exact-context for DMs (see _update_incoming_trust).
+        own_ctx = _own_ctx_or_none(buf, server, ctx, "/e2e unrevoke")
+        if own_ctx is None:
+            return weechat.WEECHAT_RC_OK if weechat else 0
+        _update_incoming_trust(handle, ctx, "trusted", own_ctx)
         _prnt_ok(buf, f"unrevoked {nick} on {ctx}")
     elif sub == "forget":
         if not rest:
@@ -2962,8 +2970,11 @@ def cmd_e2e(data, buffer, args):
         handle = _handle_or_error(buf, server, channel, nick, "/e2e forget")
         if handle is None:
             return weechat.WEECHAT_RC_OK if weechat else 0
-        # Handle-wide for DMs (see _update_incoming_trust for why).
-        _delete_incoming_rows(handle, ctx)
+        # Exact-context for DMs (see _update_incoming_trust for why).
+        own_ctx = _own_ctx_or_none(buf, server, ctx, "/e2e forget")
+        if own_ctx is None:
+            return weechat.WEECHAT_RC_OK if weechat else 0
+        _delete_incoming_rows(handle, ctx, own_ctx)
         _prnt_warn(buf, f"forgotten {nick} on {ctx}")
     elif sub == "handshake":
         if not rest:


### PR DESCRIPTION
## Summary

Ports `docs/rpe2e-dm-addendum.md` (the June 2026 repartee+lurker agreement) to both companion scripts, completing DM E2E interop with the Rust client. Before this, repartee→script DMs never authenticated (AAD `@<recipient>` vs recomputed `@<sender>`), script↔script DMs failed both ways, and the irssi script had no DM enable path at all.

- **Own-handle tracking** (volatile, per server), mirroring the Rust client: one-shot self-USERHOST at registration/load, RPL_USERHOST(302) parsing with the same normalization as Rust's `parse_userhost_reply`, own CHGHOST, and (weechat) echo-message capture — whose own-ciphertext echoes are now swallowed instead of triggering KEYREQs to ourselves. irssi additionally falls back to core's join-seeded `$server->{userhost}`.
- **Inbound DM wires** decrypt under `@<own>`; while the own handle is unknown the wire is dropped with a throttled notice — never keyed by `@<sender>`, never auto-KEYREQ'd (addendum-mandated fail-closed).
- **KEYREQs** (auto, `/e2e handshake`, reciprocals) stamp `c=@<own>` for DMs; KEYRSP/REKEY handlers already used the wire `c=` verbatim, so sessions land under the right key automatically.
- **Commands**: config/accept/decline stay peer-keyed; verify/revoke/unrevoke/forget/list understand both DM context forms; irssi `/e2e on|off|mode` now work in query buffers (peer-keyed config, live-first handle resolution).
- No migration: stale sender-keyed rows never match again; the transport self-heals via session miss → auto-KEYREQ under the correct context.

## Verification

- Golden DM AAD vector (`src/e2e/wire.rs::build_aad_golden_vector_dm`) asserted **byte-for-byte** against both scripts' `build_aad`.
- 28 Python behavioral checks (302/CHGHOST/echo capture incl. normalization edge cases, DM decrypt ctx selection, unknown-own drop with no KEYREQ, auto-KEYREQ `c=` stamping, channel paths unchanged, own-echo swallow/passthrough) + `py_compile`.
- Perl checks against the shipped subs (golden vector, userhost normalization, reciprocal-ctx) + `perl -c` with stubbed runtime modules.
- Cross-checked against irssi core source: `server->userhost` seeding/CHGHOST gaps that motivated the script-side store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix recipient-keyed DM context in WeeChat and Irssi E2E companion scripts
> - Both [rpe2e.py](https://github.com/outragedevs/repartee/pull/31/files#diff-7a10381b6b240b56c951a781a4bae33819af169405d81189bbacf71007a9e591) and [rpe2e.pl](https://github.com/outragedevs/repartee/pull/31/files#diff-ba1f85f5ba50bef6e086f138503b43c4536be6e763afe59d9487d7be4ba0df85) now track the client's own peer-visible `ident@host` per server, seeded via self-WHOIS on connect and updated from JOIN, 396, and CHGHOST events.
> - DM session contexts are keyed by `@<own_handle>` instead of `@<sender>`, aligning incoming session storage with the recipient's identity rather than the sender's.
> - Trust commands (`revoke`, `unrevoke`, `forget`, `handshake`, `verify`) now refuse with a clear message until own identity is learned; mutations update both the peer-keyed trust marker and the `@<own>` session row.
> - Own-copy/echo messages (bouncer playback) are decrypted using the outgoing key and suppressed from triggering auto-KEYREQ, with live echo-message copies correlated and swallowed in the WeeChat script.
> - Risk: DMs received before own handle is learned are dropped with a throttled notice rather than processed; auto-KEYREQ is suppressed during this window.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f78b1e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->